### PR TITLE
AB-117: add "and" separator before period function

### DIFF
--- a/CLI/local-cli-fe-full/src/pages/SqlQueryGenerator.js
+++ b/CLI/local-cli-fe-full/src/pages/SqlQueryGenerator.js
@@ -362,7 +362,11 @@ const SqlQueryGenerator = ({ node }) => {
           }
           return `period(${period.timeScale}, ${period.amount}, ${startValue}, ${period.column})`;
         });
-        whereParts.push(...periodStrings);
+        if (validConditions.length > 0) {
+          whereParts.push('and ' + periodStrings.join(' and '));
+        } else {
+          whereParts.push(periodStrings.join(' and '));
+        }
       }
       
       if (whereParts.length > 0) {


### PR DESCRIPTION
AB-117: add "and" separator before period function


Query now is

run client () sql new_company format = json "SELECT insert_timestamp, timestamp, value FROM temperature_6 WHERE timestamp > '0' AND value > '1' and period(week, 1, NOW(), timestamp)"