### PR TITLE
fixing display bug on sql query when format=table. the change now mak…

### DIFF
--- a/CLI/local-cli-backend/main.py
+++ b/CLI/local-cli-backend/main.py
@@ -22,7 +22,7 @@ import logging
 
 logger = logging.getLogger("uvicorn.error")
 
-from parsers import parse_response
+from parsers import parse_response, check_format_table_sql_query
 from classes import *
 from sql_router import sql_router
 from file_auth_router import file_auth_router
@@ -345,8 +345,16 @@ def send_command(conn: Connection, command: Command):
         raise HTTPException(status_code=403, detail="Feature 'client' is disabled")
     try:
         normalized_cmd = command.cmd.strip()
-        force_raw_text = should_force_raw_text(normalized_cmd)
-        raw_response = make_request(conn.conn, command.type, normalized_cmd)
+        ### All SQL requests should be sent with format=json. if table format, then we will update the result in the display
+        is_table, sql_json_request = check_format_table_sql_query(normalized_cmd)
+        # if sql query and format=table
+        if is_table:
+            raw_response = make_request(conn.conn, command.type, sql_json_request)
+            force_raw_text = should_force_raw_text(sql_json_request)
+        else:
+            # send original query
+            raw_response = make_request(conn.conn, command.type, normalized_cmd)
+            force_raw_text = should_force_raw_text(normalized_cmd)
         print("raw_response", raw_response)
 
         # Check if the response is already an error response
@@ -359,6 +367,12 @@ def send_command(conn: Connection, command: Command):
             return {"type": "raw", "data": str(raw_response) if raw_response is not None else ""}
 
         structured_data = parse_response(raw_response)
+        # if sql table format was specified
+        if is_table:
+            structured_data['type'] = "table" # set type to table
+            structured_data['data'] = structured_data['data'].get("Query") # return data list not dictionary
+            structured_data['additional_content'] = str({"Statistics": raw_response.get("Statistics")})
+
         print("structured_data", structured_data)
         return structured_data
     except Exception as e:

--- a/CLI/local-cli-backend/main.py
+++ b/CLI/local-cli-backend/main.py
@@ -345,16 +345,18 @@ def send_command(conn: Connection, command: Command):
         raise HTTPException(status_code=403, detail="Feature 'client' is disabled")
     try:
         normalized_cmd = command.cmd.strip()
-        ### All SQL requests should be sent with format=json. if table format, then we will update the result in the display
-        is_table, sql_json_request = check_format_table_sql_query(normalized_cmd)
-        # if sql query and format=table
-        if is_table:
-            raw_response = make_request(conn.conn, command.type, sql_json_request)
-            force_raw_text = should_force_raw_text(sql_json_request)
-        else:
-            # send original query
-            raw_response = make_request(conn.conn, command.type, normalized_cmd)
-            force_raw_text = should_force_raw_text(normalized_cmd)
+
+        # SQL requests should be sent with format=json.
+        # If the user requested format=table, we request JSON and handle table display later.
+        is_table, request_cmd = check_format_table_sql_query(normalized_cmd)
+
+        # If not a table-format SQL query, keep the original command.
+        if not is_table:
+            request_cmd = normalized_cmd
+
+        raw_response = make_request(conn.conn, command.type, request_cmd)
+        force_raw_text = should_force_raw_text(request_cmd)
+
         print("raw_response", raw_response)
 
         # Check if the response is already an error response

--- a/CLI/local-cli-backend/parsers.py
+++ b/CLI/local-cli-backend/parsers.py
@@ -2,7 +2,6 @@
 import json
 
 def parse_table_fixed(text: str) -> list:
-    lines = text.strip().splitlines()
 
     lines = text.strip().splitlines()
     if len(lines) < 2:
@@ -120,6 +119,99 @@ def parse_table_fixed(text: str) -> list:
             new_row = dict(zip(headers, parts))
             data.append(new_row)
     return {"data": data, "additional_info": additional_info}
+
+
+def check_format_table_sql_query(text: str) -> tuple[bool, str]:
+    """
+    Check whether a command string is a SQL query using table format, and if so,
+    return a modified command where the table format is changed to JSON.
+
+    Supported command forms:
+
+        run client (...) sql ... format=table
+        sql ... format=table
+
+    The second form starts directly with "sql", so "run" and "client" are not
+    required.
+
+    The format option may be written with or without spaces around the equals
+    sign, for example:
+
+        format=table
+        format = table
+        format= table
+        format =table
+
+    Args:
+        text: The command string to inspect.
+
+    Returns:
+        A tuple containing:
+            - True if the command is a SQL query using table format.
+            - The updated command string with format=json if matched,
+              otherwise the original command string.
+    """
+
+    # Normalize equals signs so all variants of "format=table" become:
+    # ["format", "=", "table"]
+    tokens = text.replace("=", " = ").split()
+
+    # Empty input cannot match.
+    if not tokens:
+        return False, text
+
+    first = tokens[0].lower()
+
+    # Case 1:
+    # The command starts directly with SQL, so "run client" is not required.
+    if first == "sql":
+        required = {"sql"}
+        found = {"sql"}
+
+    # Case 2:
+    # The command must begin with: run client
+    elif (
+        len(tokens) >= 2
+        and tokens[0].lower() == "run"
+        and tokens[1].lower() == "client"
+    ):
+        required = {"run", "client", "sql"}
+        found = {"run", "client"}
+
+    # Early stop:
+    # If the command does not start with either "sql" or "run client",
+    # it cannot be the command form we care about.
+    else:
+        return False, text
+
+    # Tracks where the "format = table" sequence starts.
+    format_index = None
+
+    i = 0
+    while i < len(tokens):
+        token = tokens[i].lower()
+
+        # Track required command keywords.
+        if token in required:
+            found.add(token)
+
+        # Detect: format = table
+        if (
+            token == "format"
+            and i + 2 < len(tokens)
+            and tokens[i + 1] == "="
+            and tokens[i + 2].lower() == "table"
+        ):
+            format_index = i
+
+        # Stop early once all required pieces have been found.
+        if found == required and format_index is not None:
+            tokens[format_index:format_index + 3] = ["format=json"]
+            return True, " ".join(tokens)
+
+        i += 1
+
+    return False, text.strip()
 
 
 

--- a/CLI/local-cli-backend/usr-mgm/bookmarks.json
+++ b/CLI/local-cli-backend/usr-mgm/bookmarks.json
@@ -34,6 +34,15 @@
       },
       "description": "",
       "created_at": "2026-04-08T17:11:08.314317",
+      "is_default": false
+    },
+    {
+      "id": "2084aa96-0eae-4671-bde0-ffca465ef839",
+      "node": {
+        "conn": "172.233.208.212:32349"
+      },
+      "description": "",
+      "created_at": "2026-05-15T13:48:17.287091",
       "is_default": true
     }
   ]


### PR DESCRIPTION
…es all sql queries with format=table and then we change the format given to the front end


Fixed bug that caused table display format issue in the front end. 

KEY FIX:

All SQL queries with format=table are sent as format=json. then I give the frontend the correct format. The value here is that before the code was parsing the returned string character-by-character. Now it's all based on JSON operations!

How to test:
1. Run the following query against the test network ```run client () sql monitoring format=table and extend=(+node_name, +ip) "select node_type, timestamp, packets_recv::format(:,), packets_sent::format(:,) from node_insight where period(minute, 15, now(), timestamp) order by timestamp;"```

Before the fix: the display in the front end was wrong (the issue starts around row 60). Now it's being correctly displayed