### PR TITLE
Addition of a plugin marketplace into the Remote-GUI

### DIFF
--- a/CLI/local-cli-backend/build-plugin.py
+++ b/CLI/local-cli-backend/build-plugin.py
@@ -1,0 +1,472 @@
+import argparse
+import ast
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parent / "buildfiles" / "templates"
+
+JS_IMPORT_RE = re.compile(
+    r"""(?:from|import)\s+['"](\.[^'"]+)['"]|require\s*\(\s*['"](\.[^'"]+)['"]\s*\)|import\s*\(\s*['"](\.[^'"]+)['"]\s*\)"""
+)
+JS_EXTENSIONS = {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx"}
+
+
+def log(msg):
+    print(f"[build] {msg}", flush=True)
+
+
+def fatal(msg):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def slug_to_pascal(slug):
+    return "".join(part.capitalize() for part in re.split(r"[-_]+", slug) if part)
+
+
+def path_is_inside(parent, child):
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def load_template(name):
+    path = TEMPLATES_DIR / name
+    if not path.is_file():
+        fatal(f"Missing template file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def write_template(dest_path, template_name, **substitutions):
+    text = load_template(template_name)
+    for key, val in substitutions.items():
+        text = text.replace(f"@@{key}@@", val)
+    dest_path.write_text(text, encoding="utf-8")
+
+
+def _is_stdlib_module(name):
+    root = name.split(".")[0]
+    return root in getattr(sys, "stdlib_module_names", set()) or root in getattr(
+        sys, "builtin_module_names", ()
+    )
+
+
+def _module_paths(name):
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return []
+    if spec is None:
+        return []
+
+    paths = []
+    if spec.origin and spec.origin != "built-in":
+        paths.append(Path(spec.origin).resolve())
+    for loc in getattr(spec, "submodule_search_locations", None) or []:
+        if loc:
+            paths.append(Path(loc).resolve())
+    return paths
+
+
+def _check_absolute_import(
+    module_name, plugin_root, plugins_root, problems, check_packages=True
+):
+    if not check_packages:
+        return
+
+    if _is_stdlib_module(module_name):
+        return
+
+    stdlib_base = Path(sys.base_prefix).resolve()
+
+    for loc in _module_paths(module_name):
+        if path_is_inside(plugin_root, loc) or path_is_inside(plugins_root, loc):
+            continue
+        in_stdlib = path_is_inside(stdlib_base / "lib", loc) or path_is_inside(
+            stdlib_base, loc
+        )
+        in_site = "site-packages" in loc.parts or "dist-packages" in loc.parts
+        if in_stdlib or in_site:
+            continue
+        problems.append(f"{module_name} resolves outside backend plugins tree: {loc}")
+
+
+def check_python_imports(plugin_root, check_packages=True):
+    plugin_root = plugin_root.resolve()
+    plugins_root = plugin_root.parent.resolve()
+    problems = []
+
+    for py_file in sorted(plugin_root.rglob("*.py")):
+        if "__pycache__" in py_file.parts:
+            continue
+
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        except SyntaxError as e:
+            problems.append(f"{py_file}: syntax error: {e}")
+            continue
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    _check_absolute_import(
+                        alias.name.split(".")[0],
+                        plugin_root,
+                        plugins_root,
+                        problems,
+                        check_packages,
+                    )
+
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    anchor = py_file.parent
+                    for _ in range(node.level - 1):
+                        anchor = anchor.parent
+
+                    rel = (node.module or "").replace(".", os.sep)
+                    candidate = anchor / rel if rel else anchor
+                    resolved = None
+                    for probe in [
+                        candidate / "__init__.py",
+                        candidate,
+                        Path(str(anchor / rel) + ".py"),
+                    ]:
+                        if probe.exists():
+                            resolved = probe.resolve()
+                            break
+
+                    if (
+                        resolved
+                        and not path_is_inside(plugin_root, resolved)
+                        and not path_is_inside(plugins_root, resolved)
+                    ):
+                        problems.append(
+                            f"{py_file}: relative import escapes plugin tree "
+                            f"(level={node.level}, module={node.module!r}) -> {resolved}"
+                        )
+                elif node.module:
+                    _check_absolute_import(
+                        node.module.split(".")[0],
+                        plugin_root,
+                        plugins_root,
+                        problems,
+                        check_packages,
+                    )
+
+    if problems:
+        fatal(
+            "Backend references modules outside local-cli-backend/plugins:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+def check_js_imports(plugin_fe_root, check_packages):
+    plugin_fe_root = plugin_fe_root.resolve()
+    problems = []
+
+    for f in sorted(plugin_fe_root.rglob("*")):
+        if not f.is_file() or f.suffix.lower() not in JS_EXTENSIONS:
+            continue
+        if "node_modules" in f.parts or f.name == "devContext.js":
+            continue
+
+        for line_num, line in enumerate(
+            f.read_text(encoding="utf-8", errors="ignore").splitlines(), 1
+        ):
+            for match in JS_IMPORT_RE.finditer(line):
+                rel = next(g for g in match.groups() if g)
+                base = (f.parent / rel).resolve()
+
+                resolved = None
+                for probe in [
+                    base,
+                    *(Path(str(base) + ext) for ext in (".js", ".jsx", ".json")),
+                ]:
+                    if probe.exists():
+                        resolved = probe
+                        break
+
+                if resolved and not path_is_inside(plugin_fe_root, resolved):
+                    problems.append(
+                        f"{f}:{line_num}: {rel!r} resolves outside plugin -> {resolved}"
+                    )
+
+    if problems:
+        fatal(
+            "Frontend imports reference paths outside the plugin folder:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+def find_router_module(plugin_dir, plugin_slug):
+    router_files = sorted(plugin_dir.glob("*_router.py"))
+    if not router_files:
+        fatal(f"No '*_router.py' found under {plugin_dir}.")
+
+    def has_api_router(path):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            return False
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                if any(
+                    isinstance(t, ast.Name) and t.id == "api_router"
+                    for t in node.targets
+                ):
+                    return True
+            if isinstance(node, ast.AnnAssign):
+                if isinstance(node.target, ast.Name) and node.target.id == "api_router":
+                    return True
+        return False
+
+    valid = [p for p in router_files if has_api_router(p)]
+    if not valid:
+        fatal(
+            f"No '*_router.py' under {plugin_dir} declares a module-level `api_router`."
+        )
+
+    preferred = plugin_dir / f"{plugin_slug}_router.py"
+    chosen = preferred if preferred in valid else valid[0]
+    return chosen, chosen.stem
+
+
+def find_page_entry(src_dir, plugin_slug):
+    pages = sorted(src_dir.glob("*Page.js")) + sorted(src_dir.glob("*Page.jsx"))
+    if not pages:
+        fatal(f"No *Page.js / *Page.jsx found under {src_dir}.")
+
+    pascal = slug_to_pascal(plugin_slug)
+    for suffix in (".js", ".jsx"):
+        candidate = src_dir / f"{pascal}Page{suffix}"
+        if candidate.is_file():
+            return candidate
+
+    if len(pages) == 1:
+        return pages[0]
+
+    fatal(
+        f"Multiple page components found: {', '.join(p.name for p in pages)}. "
+        f"Rename one to XPage.js/jsx or {pascal}Page.js/jsx."
+    )
+
+
+def find_fe_plugin_dir(fe_root, plugin_slug):
+    for candidate in [
+        fe_root / "plugins" / plugin_slug,
+        fe_root / "src" / "plugins" / plugin_slug,
+    ]:
+        if candidate.is_dir():
+            return candidate.resolve()
+    fatal(f"Frontend plugin folder not found for {plugin_slug!r} under {fe_root}.")
+
+
+def write_backend_extras(backend_dir, router_mod):
+    main_py = backend_dir / "main.py"
+    if main_py.is_file():
+        log("main.py already exists, leaving it alone.")
+        return
+    write_template(main_py, "main.py.template", ROUTER_MODULE=router_mod)
+    log("Created main.py from template.")
+
+
+def write_frontend_extras(frontend_dir, src_dir, plugin_slug, page_path):
+    write_template(
+        frontend_dir / "index.html", "index.html.template", PLUGIN=plugin_slug
+    )
+    write_template(frontend_dir / "config.js", "config.js")
+    write_template(
+        frontend_dir / "vite.config.js",
+        "vite.config.js.template",
+        PLUGIN=plugin_slug,
+        EXPOSE_PATH=f"./src/{page_path.name}",
+        EXPOSE_MODULE=f"{page_path.name}",
+    )
+
+    for stale in src_dir.rglob("pluginHost.js"):
+        stale.unlink()
+        log(f"Removed stale {stale.name}")
+
+    bridge_code = load_template("pluginHost.js")
+    bridge_targets = {src_dir / "devContext.js"} | set(src_dir.rglob("devContext.js"))
+    for target in sorted(bridge_targets):
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(bridge_code, encoding="utf-8")
+        log(f"Wrote host bridge -> {target.relative_to(src_dir)}")
+
+    write_template(
+        src_dir / "main.js", "main.js.template", PAGE_BASENAME=page_path.stem
+    )
+
+
+def generate_requirements(backend_dir):
+    attempts = [
+        [sys.executable, "-m", "pipreqs", ".", "--force", "--encoding", "utf-8"],
+        ["pipreqs", ".", "--force", "--encoding", "utf-8"],
+        [
+            sys.executable,
+            "-m",
+            "pigar",
+            "generate",
+            "-f",
+            "requirements.txt",
+            "-p",
+            ".",
+        ],
+        ["pigar", "generate", "-f", "requirements.txt", "-p", "."],
+    ]
+    for cmd in attempts:
+        try:
+            result = subprocess.run(
+                cmd, cwd=backend_dir, capture_output=True, text=True
+            )
+        except FileNotFoundError:
+            continue
+        if result.returncode == 0 and (backend_dir / "requirements.txt").is_file():
+            log(f"requirements.txt written via {cmd[0]}")
+            return
+    fatal("Could not generate requirements.txt — install pipreqs or pigar and retry.")
+
+
+def zip_bundle(output_dir, plugin_slug):
+    zip_path = output_dir / f"{plugin_slug}-plugin.zip"
+    log(f"Zipping -> {zip_path.name}")
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for subtree in (output_dir / "backend", output_dir / "frontend"):
+            if not subtree.is_dir():
+                fatal(f"Cannot zip: missing {subtree.name}/ folder at {subtree}")
+            for path in sorted(subtree.rglob("*")):
+                if path.is_file():
+                    zf.write(path, path.relative_to(output_dir).as_posix())
+    log(f"Archive ready: {zip_path}")
+    return zip_path
+
+
+def main():
+    script_dir = Path(__file__).resolve().parent
+    cli_root = script_dir.parent
+
+    parser = argparse.ArgumentParser(description="Build a CLI plugin bundle.")
+    parser.add_argument("--plugin", required=True, help="Plugin slug (folder name).")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output directory (default: CLI/built-plugins/<plugin>).",
+    )
+
+    parser.add_argument(
+        "--skip-be-package-check",
+        action="store_true",
+        help="Skip installed package validation for backend Python imports.",
+    )
+
+    parser.add_argument(
+        "--skip-fe-package-check",
+        action="store_true",
+        help="Skip installed package validation for frontend JS imports.",
+    )
+    parser.add_argument(
+        "--skip-all-package-check",
+        action="store_true",
+        help="Skip installed package validation for both backend and frontend.",
+    )
+
+    parser.add_argument(
+        "--skip-be-checks",
+        action="store_true",
+        help="Skips all validation for backend.",
+    )
+
+    parser.add_argument(
+        "--skip-fe-checks",
+        action="store_true",
+        help="Skips all validation for backend.",
+    )
+
+    args = parser.parse_args()
+
+    skip_be = args.skip_be_package_check or args.skip_all_package_check
+    skip_fe = args.skip_fe_package_check or args.skip_all_package_check
+
+    plugin = args.plugin.strip()
+    if not plugin:
+        fatal("--plugin must be non-empty")
+
+    output_dir = (
+        Path(args.output).expanduser().resolve()
+        if args.output
+        else cli_root / "built-plugins" / plugin
+    )
+    backend_src = script_dir / "plugins" / plugin
+    fe_root = cli_root / "local-cli-fe-full"
+
+    log(f"Plugin: {plugin!r}   Output: {output_dir}")
+
+    if not backend_src.is_dir():
+        fatal(f"Backend plugin folder not found: {backend_src}")
+
+    if not args.skip_be_checks:
+        log("Checking Python imports...")
+        check_python_imports(backend_src, check_packages=not skip_be)
+
+    log("Finding router module...")
+    router_path, router_mod = find_router_module(backend_src, plugin)
+    log(f"Router: {router_path.name}  (module: {router_mod!r})")
+
+    log("Resolving frontend plugin directory...")
+    fe_plugin = find_fe_plugin_dir(fe_root, plugin)
+
+    if not args.skip_fe_checks:
+        log("Checking JS imports...")
+        check_js_imports(fe_plugin, check_packages=not skip_fe)
+
+    backend_dest = output_dir / "backend"
+    if backend_dest.exists():
+        shutil.rmtree(backend_dest)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(backend_src, backend_dest)
+    log(f"Copied backend -> {backend_dest}")
+
+    log("Generating requirements.txt...")
+    generate_requirements(backend_dest)
+    write_backend_extras(backend_dest, router_mod)
+
+    frontend_dir = output_dir / "frontend"
+    if frontend_dir.exists():
+        shutil.rmtree(frontend_dir)
+    frontend_dir.mkdir()
+
+    pkg_json = fe_root / "package.json"
+    if not pkg_json.is_file():
+        fatal(f"Missing package.json at {pkg_json}")
+    shutil.copy2(pkg_json, frontend_dir / "package.json")
+
+    src_dir = frontend_dir / "src"
+    src_dir.mkdir()
+    for entry in fe_plugin.iterdir():
+        dest = src_dir / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, dest)
+        else:
+            shutil.copy2(entry, dest)
+    log(f"Copied frontend source -> {src_dir}")
+
+    page_path = find_page_entry(src_dir, plugin)
+    log(f"Page entry: {page_path.name}")
+    write_frontend_extras(frontend_dir, src_dir, plugin, page_path)
+
+    zip_path = zip_bundle(output_dir, plugin)
+
+    print(f"\nDone!\n  Output:  {output_dir}\n  Archive: {zip_path}\n", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/CLI/local-cli-backend/buildfiles/templates/config.js
+++ b/CLI/local-cli-backend/buildfiles/templates/config.js
@@ -1,0 +1,4 @@
+window._env_ = {
+  REACT_APP_API_URL: "http://localhost:8000",
+  VITE_API_URL: "http://localhost:8080",
+};

--- a/CLI/local-cli-backend/buildfiles/templates/index.html.template
+++ b/CLI/local-cli-backend/buildfiles/templates/index.html.template
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@@PLUGIN@@ for Remote-GUI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/CLI/local-cli-backend/buildfiles/templates/main.js.template
+++ b/CLI/local-cli-backend/buildfiles/templates/main.js.template
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import @@PAGE_BASENAME@@ from "./@@PAGE_BASENAME@@";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <@@PAGE_BASENAME@@ />
+  </React.StrictMode>
+);

--- a/CLI/local-cli-backend/buildfiles/templates/main.py.template
+++ b/CLI/local-cli-backend/buildfiles/templates/main.py.template
@@ -1,0 +1,5 @@
+from fastapi import FastAPI
+from @@ROUTER_MODULE@@ import api_router
+
+app = FastAPI()
+app.include_router(api_router)

--- a/CLI/local-cli-backend/buildfiles/templates/pluginHost.js
+++ b/CLI/local-cli-backend/buildfiles/templates/pluginHost.js
@@ -1,0 +1,112 @@
+/**
+ * Plugin ↔ main app (host) bridge — single file to copy or publish as a package.
+ *
+ * The host must set this before the remote runs:
+ *   globalThis.__ANYLOG_PLUGIN_HOST_CONTEXT__ = { services, utils, components, ... }
+ * Paths mirror the host's src layout (e.g. services.api → host folder `services` + file `api`).
+ *
+ * ---------------------------------------------------------------------------
+ * Usage (any module in the plugin — no React required)
+ * ---------------------------------------------------------------------------
+ *   import host from "host";
+ *   host.services.api.sendCommand({ ... });
+ *   const DataTable = host.components.DataTable;
+ *   host.utils.tableExport.toCsv?.(...);
+ *
+ * Host functions, components, and "hooks" (if the host exports them as functions)
+ * are all reachable the same way — they live on the injected object tree.
+ *
+ * ---------------------------------------------------------------------------
+ * Advanced: resolve by string path
+ * ---------------------------------------------------------------------------
+ *   import { getFromHost, getHostContext } from "host";
+ *   getFromHost("services.api").sendCommand(...);
+ *   getHostContext() // full root object
+ */
+
+const GLOBAL_KEY = "__ANYLOG_PLUGIN_HOST_CONTEXT__";
+
+/**
+ * @returns {Record<string, unknown>} Root object injected by the host.
+ */
+export function getHostContext() {
+  const ctx = globalThis?.[GLOBAL_KEY];
+  if (!ctx) {
+    throw new Error(
+      "[pluginHost] Missing host injection. Open this plugin from the main app (not standalone) so the host can set __ANYLOG_PLUGIN_HOST_CONTEXT__.",
+    );
+  }
+  return ctx;
+}
+
+const walk = (obj, keys) =>
+  keys.reduce(
+    (acc, key) => (acc == null || key === "" ? acc : acc[key]),
+    obj,
+  );
+
+/**
+ * @param {string} dottedPath e.g. "services.api" or "components.DataTable"
+ */
+function resolveDotted(ctx, dottedPath) {
+  const keys = dottedPath.split(".").filter(Boolean);
+  return walk(ctx, keys);
+}
+
+/**
+ * Read one leaf or namespace from the host by path.
+ * @param {string} path e.g. "services/api" or "components.security.LoginForm"
+ */
+export function getFromHost(path) {
+  const dotted = String(path).replaceAll("/", ".");
+  const value = resolveDotted(getHostContext(), dotted);
+  if (value === undefined) {
+    throw new Error(`[pluginHost] Nothing registered at "${path}".`);
+  }
+  return value;
+}
+
+/**
+ * Objects that support further property access (namespace / nested folders on host).
+ * Functions, components, and primitives are returned as-is.
+ */
+function shouldProxyDeepValue(value) {
+  if (value === null || typeof value !== "object") return false;
+  if (Array.isArray(value)) return false;
+  const tag = Object.prototype.toString.call(value);
+  if (tag === "[object Object]") return true;
+  if (tag === "[object Module]") return true;
+  return false;
+}
+
+/**
+ * `host` is a lazy view of `getHostContext()` so you can write host.services.api.sendCommand.
+ */
+function createHostProxy(segmentPath) {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (typeof prop !== "string") return undefined;
+        if (prop === "then") return undefined;
+        const next = segmentPath ? `${segmentPath}/${prop}` : prop;
+        const dotted = next.replaceAll("/", ".");
+        const value = resolveDotted(getHostContext(), dotted);
+
+        if (value === undefined) {
+          throw new Error(
+            `[pluginHost] Nothing registered at "${next.replaceAll("/", ".")}".`,
+          );
+        }
+        if (shouldProxyDeepValue(value)) {
+          return createHostProxy(next);
+        }
+        return value;
+      },
+    },
+  );
+}
+
+const host = createHostProxy();
+export { host };
+export default host;

--- a/CLI/local-cli-backend/buildfiles/templates/vite.config.js.template
+++ b/CLI/local-cli-backend/buildfiles/templates/vite.config.js.template
@@ -1,0 +1,76 @@
+// plugin vite.config.js
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { federation } from "@module-federation/vite";
+
+export default defineConfig({
+  plugins: [
+    react({
+      include: "**/*.{js,jsx}",
+      jsxRuntime: "automatic",
+    }),
+    federation({
+      name: "@@PLUGIN@@",
+      filename: "remoteEntry.js",
+      manifest: true,
+      remotes: {},
+      exposes: {
+        "./PluginApp": "@@EXPOSE_PATH@@",
+        "./@@EXPOSE_MODULE@@": "@@EXPOSE_PATH@@",
+      },
+      shared: {
+        react: {
+          singleton: true,
+          requiredVersion: false,
+          eager: false,
+          import: false,
+        },
+        "react-dom": {
+          singleton: true,
+          requiredVersion: false,
+          eager: false,
+          import: false,
+        },
+        "react/jsx-runtime": {
+          singleton: true,
+          requiredVersion: false,
+          eager: false,
+          import: false,
+        },
+        tslib: { singleton: true, requiredVersion: false },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      // Host bridge is emitted as devContext.js (`import host from "host"`).
+      host: "/src/devContext.js",
+    },
+    dedupe: [], // override @vitejs/plugin-react's automatic dedupe
+  },
+  optimizeDeps: {
+    exclude: [
+      "react",
+      "react-dom",
+      "react/jsx-runtime",
+      "react/jsx-dev-runtime",
+    ],
+    esbuildOptions: {
+      loader: { ".js": "jsx" },
+    },
+  },
+  esbuild: {
+    loader: "jsx",
+    include: /src\/.*\.js$/,
+    exclude: [],
+  },
+  base: "/official-plugins/dev/@@PLUGIN@@/frontend/dist/",
+  build: {
+    target: "esnext",
+    minify: false,
+    cssCodeSplit: false,
+    rollupOptions: {
+      output: { format: "esm" },
+    },
+  },
+});

--- a/CLI/local-cli-backend/decorators.py
+++ b/CLI/local-cli-backend/decorators.py
@@ -1,0 +1,27 @@
+import functools
+import json
+from typing import Any
+
+from fastapi.responses import StreamingResponse
+
+
+def wrap_sse_stream(func):
+    @functools.wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> StreamingResponse:
+        generator = await func(*args, **kwargs)
+
+        async def event_formatter():
+            async for y in generator:
+                yield f"data: {json.dumps(y)}\n\n"
+
+        return StreamingResponse(
+            event_formatter(),
+            media_type="text/event-stream",
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+            },
+        )
+
+    return wrapper

--- a/CLI/local-cli-backend/feature_config.json
+++ b/CLI/local-cli-backend/feature_config.json
@@ -47,27 +47,36 @@
   },
   "plugins": {
     "reportgenerator": {
+      "slug": "anylog/reportgenerator",
       "enabled": true,
       "description": "Report Generator Plugin"
     },
     "nodecheck": {
+      "slug": "anylog/nodecheck",
       "enabled": true,
       "description": "Node Check Plugin"
     },
     "calculator": {
+      "slug": "anylog/calculator",
       "enabled": false,
       "description": "Calculator Plugin"
     },
     "grafana": {
-      "enabled": true,
+      "slug": "anylog/grafana",
+      "enabled": false,
       "description": "Grafana Dashboard Plugin"
     },
     "mcpclient": {
-      "enabled": true,
+      "slug": "anylog/mcpclient",
+      "enabled": false,
       "description": "MCP Client Plugin - Integrates Ollama with AnyLog MCP"
     },
+    "marketplace": {
+      "slug": "anylog/marketplace",
+      "enabled": true
+    },
     "sshclient": {
-      "enabled": true,
+      "enabled": false,
       "description": "SSH Client Plugin"
     },
     "uns": {

--- a/CLI/local-cli-backend/feature_config.json
+++ b/CLI/local-cli-backend/feature_config.json
@@ -63,7 +63,7 @@
     },
     "grafana": {
       "slug": "anylog/grafana",
-      "enabled": false,
+      "enabled": true,
       "description": "Grafana Dashboard Plugin"
     },
     "mcpclient": {
@@ -76,7 +76,7 @@
       "enabled": true
     },
     "sshclient": {
-      "enabled": false,
+      "enabled": true,
       "description": "SSH Client Plugin"
     },
     "uns": {

--- a/CLI/local-cli-backend/feature_config_loader.py
+++ b/CLI/local-cli-backend/feature_config_loader.py
@@ -2,17 +2,23 @@
 Feature Configuration Loader
 Loads and validates feature configuration from feature_config.json
 """
-import os
+
 import json
-from typing import Dict, Set, Optional
+import os
+from pathlib import Path
+from typing import Dict, Optional, Set
+
+from plugins.base import PluginCore
 
 # Cache for feature config
 _feature_config_cache: Optional[Dict] = None
 
+
 def get_feature_config_path() -> str:
     """Get the path to feature_config.json"""
     BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(BASE_DIR, 'feature_config.json')
+    return os.path.join(BASE_DIR, "feature_config.json")
+
 
 def load_feature_config() -> Dict:
     """
@@ -20,37 +26,30 @@ def load_feature_config() -> Dict:
     Returns cached config if already loaded, otherwise loads from file
     """
     global _feature_config_cache
-    
+
     if _feature_config_cache is not None:
         return _feature_config_cache
-    
+
     config_path = get_feature_config_path()
-    
+
     if not os.path.exists(config_path):
         print(f"⚠️  Warning: feature_config.json not found at {config_path}")
         print("⚠️  Using default: all features enabled")
         # Return default config with all features enabled
-        _feature_config_cache = {
-            "features": {},
-            "plugins": {},
-            "version": "1.0.0"
-        }
+        _feature_config_cache = {"features": {}, "plugins": {}, "version": "1.0.0"}
         return _feature_config_cache
-    
+
     try:
-        with open(config_path, 'r') as f:
+        with open(config_path, "r") as f:
             config = json.load(f)
             _feature_config_cache = config
             return config
     except Exception as e:
         print(f"❌ Error loading feature_config.json: {e}")
         print("⚠️  Using default: all features enabled")
-        _feature_config_cache = {
-            "features": {},
-            "plugins": {},
-            "version": "1.0.0"
-        }
+        _feature_config_cache = {"features": {}, "plugins": {}, "version": "1.0.0"}
         return _feature_config_cache
+
 
 def is_feature_enabled(feature_name: str) -> bool:
     """
@@ -60,11 +59,12 @@ def is_feature_enabled(feature_name: str) -> bool:
     """
     config = load_feature_config()
     features = config.get("features", {})
-    
+
     if feature_name not in features:
         return False
-    
+
     return features[feature_name].get("enabled", True)
+
 
 def is_plugin_enabled(plugin_name: str) -> bool:
     """
@@ -74,11 +74,12 @@ def is_plugin_enabled(plugin_name: str) -> bool:
     """
     config = load_feature_config()
     plugins = config.get("plugins", {})
-    
+
     if plugin_name not in plugins:
         return False
-    
+
     return plugins[plugin_name].get("enabled", True)
+
 
 def get_enabled_features() -> Set[str]:
     """Get set of all enabled feature names"""
@@ -86,11 +87,13 @@ def get_enabled_features() -> Set[str]:
     features = config.get("features", {})
     return {name for name, data in features.items() if data.get("enabled", True)}
 
+
 def get_enabled_plugins() -> Set[str]:
     """Get set of all enabled plugin names"""
     config = load_feature_config()
     plugins = config.get("plugins", {})
     return {name for name, data in plugins.items() if data.get("enabled", True)}
+
 
 def get_backend_router_for_feature(feature_name: str) -> Optional[str]:
     """Get the backend router name for a feature, if specified"""
@@ -100,8 +103,81 @@ def get_backend_router_for_feature(feature_name: str) -> Optional[str]:
         return features[feature_name].get("backend_router")
     return None
 
+
 def reload_config():
     """Force reload of feature config (useful for testing or hot-reload)"""
     global _feature_config_cache
     _feature_config_cache = None
     return load_feature_config()
+
+
+def read_feature_config() -> dict:
+    path = Path(get_feature_config_path())
+    if not path.exists():
+        return {"version": "1.0.0", "features": {}, "plugins": {}}
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {"version": "1.0.0", "features": {}, "plugins": {}}
+
+
+def write_feature_config(config: dict) -> None:
+    path = Path(get_feature_config_path())
+    path.write_text(json.dumps(config, indent=2))
+    reload_config()
+
+
+def write_plugin_feature(core: PluginCore) -> None:
+    config = load_feature_config()
+
+    config["plugins"][core.slug] = {
+        "name": core.name,
+        "enabled": True,
+        "description": core.description,
+    }
+    write_feature_config(config)
+
+
+def delete_plugin_feature(slug: str) -> None:
+    config = load_feature_config()
+
+    del config["plugins"][slug]
+    write_feature_config(config)
+
+
+def _find_plugin_config_key(plugins: dict, install_slug: str) -> Optional[str]:
+    if install_slug in plugins:
+        return install_slug
+    for k, v in plugins.items():
+        if isinstance(v, dict) and v.get("slug") == install_slug:
+            return k
+    return None
+
+
+def resolve_plugin_enabled_from_config(install_slug: str) -> bool:
+    config = load_feature_config()
+    plugins = config.get("plugins", {})
+    key = _find_plugin_config_key(plugins, install_slug)
+    if key is None:
+        return True
+    return bool(plugins[key].get("enabled", True))
+
+
+def set_plugin_enabled_by_install_slug(install_slug: str, enabled: bool) -> None:
+    config = read_feature_config()
+    plugins = config.setdefault("plugins", {})
+    key = _find_plugin_config_key(plugins, install_slug)
+    if key is None:
+        plugins.setdefault(install_slug, {})
+        plugins[install_slug]["enabled"] = enabled
+    else:
+        plugins[key]["enabled"] = enabled
+    write_feature_config(config)
+
+
+def enable_plugin_feature(slug: str) -> None:
+    set_plugin_enabled_by_install_slug(slug, True)
+
+
+def disable_plugin_feature(slug: str) -> None:
+    set_plugin_enabled_by_install_slug(slug, False)

--- a/CLI/local-cli-backend/main.py
+++ b/CLI/local-cli-backend/main.py
@@ -2,55 +2,69 @@
 import configparser
 import os
 import sys
+from pathlib import Path
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-STATIC_DIR = os.path.join(BASE_DIR, 'static')
+STATIC_DIR = os.path.join(BASE_DIR, "static")
 sys.path.append(BASE_DIR)
 SETUP_CFG_FILE = os.path.join(__file__.split("CLI")[0], "setup.cfg")
 if not os.path.isfile(SETUP_CFG_FILE):
     raise Exception(f"File not found - {SETUP_CFG_FILE}")
 
-from security.security_router import security_router
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+STATIC_DIR = os.path.join(BASE_DIR, "static")
+PLUGIN_BUILDS_DIR = Path(__file__).resolve().parent / "official-plugins"
+
+sys.path.append(BASE_DIR)
+
+import logging
+from typing import Dict
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
-from typing import Dict
-import logging
+from security.security_router import security_router
 
 logger = logging.getLogger("uvicorn.error")
 
-from parsers import parse_response
+import helpers
 from classes import *
-from sql_router import sql_router
-from file_auth_router import file_auth_router
-from file_auth import file_bookmark_node, file_set_default_bookmark
-# Import plugin loader
-from plugins.loader import load_plugins, get_plugin_order
+
 # Import feature config loader
 from feature_config_loader import (
-    is_feature_enabled, 
-    is_plugin_enabled,
     get_enabled_features,
     get_enabled_plugins,
-    load_feature_config
+    is_feature_enabled,
+    load_feature_config,
 )
-
-
+from file_auth import file_bookmark_node, file_set_default_bookmark
+from file_auth_router import file_auth_router
 
 # from helpers import make_request, grab_network_nodes, monitor_network, make_policy, send_json_data
-from helpers import make_request, grab_network_nodes, monitor_network, make_policy, send_json_data, make_preset_policy
-import helpers
+from helpers import (
+    grab_network_nodes,
+    make_policy,
+    make_request,
+    monitor_network,
+    send_json_data,
+)
+from parsers import parse_response
 
+# Import plugin loader
+from plugins.loader import get_plugin_order, load_plugins
+from plugins.manager import get_plugin_manager
+from plugins_router import plugins_router
+from sql_router import sql_router
 
 app = FastAPI()
 
-FRONTEND_URL = os.getenv('FRONTEND_URL', '')
-ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '*')
+FRONTEND_URL = os.getenv("FRONTEND_URL", "")
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*")
 
-cors_origins = [o.strip() for o in FRONTEND_URL.split(",") if o.strip()] if FRONTEND_URL else ["*"]
+cors_origins = (
+    [o.strip() for o in FRONTEND_URL.split(",") if o.strip()] if FRONTEND_URL else ["*"]
+)
 
 app.add_middleware(
     CORSMiddleware,
@@ -60,16 +74,33 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-if ALLOWED_HOSTS != '*':
+if ALLOWED_HOSTS != "*":
     hosts = [h.strip() for h in ALLOWED_HOSTS.split(",") if h.strip()]
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
 
 SCANNER_PATHS = {
-    "/json/", "/login", "/SDK/webLanguage", "/.env", "/wp-login.php",
-    "/wp-admin", "/administrator", "/phpmyadmin", "/actuator", "/solr/",
-    "/console", "/manager/html", "/cgi-bin/", "/.git", "/debug",
-    "/telescope/requests", "/vendor/", "/api/v1/", "/config.json",
-    "/remote/fgt_lang", "/boaform/", "/owa/auth/logon.aspx",
+    "/json/",
+    "/login",
+    "/SDK/webLanguage",
+    "/.env",
+    "/wp-login.php",
+    "/wp-admin",
+    "/administrator",
+    "/phpmyadmin",
+    "/actuator",
+    "/solr/",
+    "/console",
+    "/manager/html",
+    "/cgi-bin/",
+    "/.git",
+    "/debug",
+    "/telescope/requests",
+    "/vendor/",
+    "/api/v1/",
+    "/config.json",
+    "/remote/fgt_lang",
+    "/boaform/",
+    "/owa/auth/logon.aspx",
 }
 
 
@@ -79,9 +110,14 @@ async def block_scanners_middleware(request: Request, call_next):
     path = request.url.path.rstrip("/") if request.url.path != "/" else "/"
     for probe in SCANNER_PATHS:
         if path == probe.rstrip("/") or path.startswith(probe):
-            logger.warning("Blocked scanner probe: %s from %s", request.url.path, request.client.host)
+            logger.warning(
+                "Blocked scanner probe: %s from %s",
+                request.url.path,
+                request.client.host,
+            )
             return Response(status_code=404)
     return await call_next(request)
+
 
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
@@ -91,30 +127,33 @@ print("📋 Feature Configuration Loaded:")
 print(f"   Enabled features: {get_enabled_features()}")
 print(f"   Enabled plugins: {get_enabled_plugins()}")
 
+
 # Middleware to block disabled features
 @app.middleware("http")
 async def feature_check_middleware(request: Request, call_next):
     """Middleware to block access to disabled features"""
     path = request.url.path
-    
+
     # Skip feature checks for static files, docs, config, and version endpoints
-    if (path.startswith("/static/") or 
-        path.startswith("/docs") or 
-        path.startswith("/openapi.json") or
-        path == "/" or
-        path == "/version" or
-        path == "/feature-config" or
-        path == "/env-config"):
+    if (
+        path.startswith("/static/")
+        or path.startswith("/docs")
+        or path.startswith("/openapi.json")
+        or path == "/"
+        or path == "/version"
+        or path == "/feature-config"
+        or path == "/env-config"
+    ):
         response = await call_next(request)
         return response
-    
+
     # Map URL paths to feature names
     feature_path_map = {
         "/sql": "sqlquery",
         "/auth": "bookmarks",  # file_auth_router handles both bookmarks and presets
         "/security": "security",
     }
-    
+
     # Check if path matches a feature
     for prefix, feature_name in feature_path_map.items():
         if path.startswith(prefix):
@@ -126,21 +165,23 @@ async def feature_check_middleware(request: Request, call_next):
                         return Response(
                             content='{"detail": "Feature \'bookmarks\' is disabled"}',
                             status_code=403,
-                            media_type="application/json"
+                            media_type="application/json",
                         )
                 elif "preset" in path:
                     if not is_feature_enabled("presets"):
                         return Response(
                             content='{"detail": "Feature \'presets\' is disabled"}',
                             status_code=403,
-                            media_type="application/json"
+                            media_type="application/json",
                         )
                 # If neither, allow if either is enabled (backward compatibility)
-                elif not (is_feature_enabled("bookmarks") or is_feature_enabled("presets")):
+                elif not (
+                    is_feature_enabled("bookmarks") or is_feature_enabled("presets")
+                ):
                     return Response(
                         content='{"detail": "Feature is disabled"}',
                         status_code=403,
-                        media_type="application/json"
+                        media_type="application/json",
                     )
             else:
                 # Check if feature is enabled
@@ -148,10 +189,10 @@ async def feature_check_middleware(request: Request, call_next):
                     return Response(
                         content=f'{{"detail": "Feature \'{feature_name}\' is disabled"}}',
                         status_code=403,
-                        media_type="application/json"
+                        media_type="application/json",
                     )
             break
-    
+
     # Check main endpoints
     endpoint_feature_map = {
         "/send-command/": "client",
@@ -163,18 +204,19 @@ async def feature_check_middleware(request: Request, call_next):
         "/view-streaming/": "viewfiles",
         "/get-preset-policy/": "presets",
     }
-    
+
     if path in endpoint_feature_map:
         feature_name = endpoint_feature_map[path]
         if not is_feature_enabled(feature_name):
             return Response(
                 content=f'{{"detail": "Feature \'{feature_name}\' is disabled"}}',
                 status_code=403,
-                media_type="application/json"
+                media_type="application/json",
             )
-    
+
     response = await call_next(request)
     return response
+
 
 # Include routers conditionally based on feature config
 if is_feature_enabled("sqlquery"):
@@ -211,6 +253,7 @@ if REST_CONN:
 else:
     print("ℹ️  No REST_CONN env var set — skipping default connection bootstrap")
 
+
 def _get_remote_gui_version() -> str:
     """Read Remote-GUI version from setup.cfg [metadata] version (fallback: version)."""
     try:
@@ -219,16 +262,16 @@ def _get_remote_gui_version() -> str:
         if os.path.exists(SETUP_CFG_FILE):
             config = configparser.ConfigParser()
             config.read(SETUP_CFG_FILE)
-            if not config.has_section('metadata'):
-                return '—'
-            if config.has_option('metadata', 'version'):
-                v = config.get('metadata', 'version').strip()
+            if not config.has_section("metadata"):
+                return "—"
+            if config.has_option("metadata", "version"):
+                v = config.get("metadata", "version").strip()
                 if v:
                     return v
-            return config.get('metadata', 'version', fallback='—')
+            return config.get("metadata", "version", fallback="—")
     except Exception:
         pass
-    return '—'
+    return "—"
 
 
 @app.get("/version")
@@ -249,8 +292,16 @@ def get_env_config_endpoint():
         ("REST_CONN", "Default AnyLog node connection", None),
         ("REMOTE_GUI_FE", "Frontend port", "31800"),
         ("REMOTE_GUI_BE", "Backend port", "8080"),
-        ("GRAFANA_URL", "Grafana dashboard URL", "http://23.239.12.151:3100/dashboards/f/ddu0qc65783r4a/smart-city"),
-        ("ANYLOG_MCP_SSE_URL", "AnyLog MCP SSE endpoint", "http://50.116.13.109:32349/mcp/sse"),
+        (
+            "GRAFANA_URL",
+            "Grafana dashboard URL",
+            "http://23.239.12.151:3100/dashboards/f/ddu0qc65783r4a/smart-city",
+        ),
+        (
+            "ANYLOG_MCP_SSE_URL",
+            "AnyLog MCP SSE endpoint",
+            "http://50.116.13.109:32349/mcp/sse",
+        ),
         ("OLLAMA_MODEL", "Ollama LLM model", "qwen2.5:7b-instruct"),
         ("LLM_ENDPOINT", "LLM API endpoint", None),
         ("ANYLOG_REQUEST_TIMEOUT", "AnyLog request timeout (seconds)", None),
@@ -261,13 +312,15 @@ def get_env_config_endpoint():
     env_list = []
     for var_name, description, default in ENV_VARS:
         value = os.getenv(var_name)
-        env_list.append({
-            "name": var_name,
-            "value": value if value is not None else None,
-            "default": default,
-            "description": description,
-            "is_set": value is not None,
-        })
+        env_list.append(
+            {
+                "name": var_name,
+                "value": value if value is not None else None,
+                "default": default,
+                "description": description,
+                "is_set": value is not None,
+            }
+        )
     return {"environment": env_list}
 
 
@@ -288,19 +341,21 @@ def get_feature_config_endpoint():
     return {
         "features": features_status,
         "plugins": plugins_status,
-        "version": config.get("version", "1.0.0")
+        "version": config.get("version", "1.0.0"),
     }
+
 
 # Plugin order endpoint for frontend
 @app.get("/plugins/order")
 def get_plugin_order_endpoint():
     """Get the plugin order configuration for frontend display"""
-    plugins_dir = os.path.join(BASE_DIR, 'plugins')
+    plugins_dir = os.path.join(BASE_DIR, "plugins")
     plugin_order = get_plugin_order(plugins_dir)
     return {
         "plugin_order": plugin_order if plugin_order else [],
-        "has_custom_order": plugin_order is not None
+        "has_custom_order": plugin_order is not None,
     }
+
 
 # 23.239.12.151:32349
 # run client () sql edgex extend=(+node_name, @ip, @port, @dbms_name, @table_name) and format = json and timezone=Europe/Dublin  select  timestamp, file, class, bbox, status  from factory_imgs where timestamp >= now() - 1 hour and timestamp <= NOW() order by timestamp desc --> selection (columns: ip using ip and port using port and dbms using dbms_name and table using table_name and file using file) -->  description (columns: bbox as shape.rect)
@@ -313,11 +368,14 @@ def list_static_files():
         for root, dirs, filenames in os.walk(STATIC_DIR):
             for filename in filenames:
                 rel_dir = os.path.relpath(root, STATIC_DIR)
-                rel_file = os.path.join(rel_dir, filename) if rel_dir != '.' else filename
+                rel_file = (
+                    os.path.join(rel_dir, filename) if rel_dir != "." else filename
+                )
                 files.append(rel_file)
         return {"files": files}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
 
 # @app.get("/")
 def get_status():
@@ -327,6 +385,7 @@ def get_status():
     # user = supabase_get_user()
     # return {"data": user}
 
+
 # File-based authentication endpoints are now handled by file_auth_router
 
 
@@ -335,8 +394,8 @@ def should_force_raw_text(command_text: str) -> bool:
     return "get msg client" in command_text.lower()
 
 
-
 # NODE API ENDPOINTS
+
 
 @app.post("/send-command/")
 def send_command(conn: Connection, command: Command):
@@ -356,19 +415,22 @@ def send_command(conn: Connection, command: Command):
             return raw_response
 
         if command.raw_text or force_raw_text:
-            return {"type": "raw", "data": str(raw_response) if raw_response is not None else ""}
+            return {
+                "type": "raw",
+                "data": str(raw_response) if raw_response is not None else "",
+            }
 
         structured_data = parse_response(raw_response)
         print("structured_data", structured_data)
         return structured_data
     except Exception as e:
-        print(f"=== MAIN.PY ERROR ===")
+        print("=== MAIN.PY ERROR ===")
         print(f"Error type: {type(e).__name__}")
         print(f"Error message: {str(e)}")
         print(f"Command: {command.cmd}")
         print(f"Connection: {conn.conn}")
-        print(f"=== END MAIN.PY ERROR ===")
-        
+        print("=== END MAIN.PY ERROR ===")
+
         return {
             "type": "error",
             "data": f"Backend error: {str(e)}",
@@ -377,8 +439,8 @@ def send_command(conn: Connection, command: Command):
                 "error_message": str(e),
                 "command": command.cmd,
                 "connection": conn.conn,
-                "location": "main.py send_command"
-            }
+                "location": "main.py send_command",
+            },
         }
 
 
@@ -390,6 +452,7 @@ def get_connected_nodes(conn: Connection):
     connected_nodes = grab_network_nodes(conn.conn)
     return {"data": connected_nodes}
 
+
 @app.post("/monitor/")
 def monitor(conn: Connection):
     # Feature check
@@ -397,6 +460,7 @@ def monitor(conn: Connection):
         raise HTTPException(status_code=403, detail="Feature 'monitor' is disabled")
     monitored_nodes = monitor_network(conn.conn)
     return {"data": monitored_nodes}
+
 
 @app.post("/submit-policy/")
 def submit_policy(conn: Connection, policy: Policy):
@@ -421,7 +485,9 @@ def send_data(conn: Connection, dbconn: DBConnection, data: list[Dict]):
     print("table", dbconn.table)
     print("data", type(data))
 
-    raw_response = send_json_data(conn=conn.conn, dbms=dbconn.dbms, table=dbconn.table, data=data)
+    raw_response = send_json_data(
+        conn=conn.conn, dbms=dbconn.dbms, table=dbconn.table, data=data
+    )
 
     structured_data = parse_response(raw_response)
     return structured_data
@@ -438,6 +504,7 @@ def send_data(conn: Connection, dbconn: DBConnection, data: list[Dict]):
 
 # All preset endpoints are now handled by file_auth_router
 
+
 @app.post("/get-preset-policy/")
 def get_preset_policy():
     """
@@ -449,42 +516,43 @@ def get_preset_policy():
 
     resp = helpers.get_preset_base_policy("23.239.12.151:32349")
     parsed = parse_response(resp)
-    lb = parsed['data']['bookmark']['bookmarks']
+    lb = parsed["data"]["bookmark"]["bookmarks"]
     print("list of bookmarks:", lb)
     filtered_lb = {key: value for key, value in lb.items() if isinstance(value, dict)}
-    
+
     return {"data": filtered_lb}
 
 
 def construct_streaming_url(blob, connectInfo):
     """Construct streaming URL for a blob"""
     # Use the blob's node IP and port, not the connected node
-    ip = blob.get('ip', '')
-    port = blob.get('port', '')
-    
+    ip = blob.get("ip", "")
+    port = blob.get("port", "")
+
     # If blob doesn't have ip/port, fall back to connected node
     if not ip or not port:
         if isinstance(connectInfo, str):
             # If connectInfo is a string like "23.239.12.151:32349", parse it
-            if ':' in connectInfo:
-                ip, port = connectInfo.split(':', 1)
+            if ":" in connectInfo:
+                ip, port = connectInfo.split(":", 1)
             else:
                 ip = connectInfo
-                port = '32349'  # default port
+                port = "32349"  # default port
         else:
             # If connectInfo is a dict, extract ip and port
-            ip = connectInfo.get('ip', '')
-            port = connectInfo.get('port', '')
-    
+            ip = connectInfo.get("ip", "")
+            port = connectInfo.get("port", "")
+
     # Extract blob details
-    dbms = blob.get('dbms_name', '')
-    table = blob.get('video_table') or blob.get('table_name', '')
-    blob_id = blob.get('file', '')  # Use 'file' instead of 'id' as blob_id
-    
+    dbms = blob.get("dbms_name", "")
+    table = blob.get("video_table") or blob.get("table_name", "")
+    blob_id = blob.get("file", "")  # Use 'file' instead of 'id' as blob_id
+
     # Construct the streaming URL using the blob's node
     streaming_url = f"http://{ip}:{port}/?User-Agent=AnyLog/1.23?command=file retrieve where dbms={dbms} and table={table} and id={blob_id} and stream=true?cb="
-    
+
     return streaming_url
+
 
 @app.post("/view-streaming/")
 def view_streaming_blobs(request: dict):
@@ -492,56 +560,59 @@ def view_streaming_blobs(request: dict):
     if not is_feature_enabled("viewfiles"):
         raise HTTPException(status_code=403, detail="Feature 'viewfiles' is disabled")
     try:
-        print(f"=== STREAMING REQUEST ===")
+        print("=== STREAMING REQUEST ===")
         print(f"Request type: {type(request)}")
-        print(f"Request keys: {request.keys() if isinstance(request, dict) else 'Not a dict'}")
+        print(
+            f"Request keys: {request.keys() if isinstance(request, dict) else 'Not a dict'}"
+        )
         print(f"Full request: {request}")
-        print(f"=== END STREAMING REQUEST ===")
-        
+        print("=== END STREAMING REQUEST ===")
+
         # Extract connection and blob information
-        connectInfo = request.get('connectInfo', {})
-        blobs = request.get('blobs', {}).get('blobs', [])
-        
+        connectInfo = request.get("connectInfo", {})
+        blobs = request.get("blobs", {}).get("blobs", [])
+
         print(f"ConnectInfo: {connectInfo} (type: {type(connectInfo)})")
-        print(f"Blobs: {blobs} (type: {type(blobs)}, length: {len(blobs) if isinstance(blobs, list) else 'N/A'})")
-        
+        print(
+            f"Blobs: {blobs} (type: {type(blobs)}, length: {len(blobs) if isinstance(blobs, list) else 'N/A'})"
+        )
+
         # Construct streaming URLs for each blob
         streaming_urls = []
         for i, blob in enumerate(blobs):
             print(f"Processing blob {i}: {blob}")
             url = construct_streaming_url(blob, connectInfo)
-            streaming_urls.append({
-                'id': blob.get('file', ''),  # Use file as id
-                'file': blob.get('file', ''),
-                'streaming_url': url,
-                'dbms': blob.get('dbms_name', ''),
-                'table': blob.get('video_table') or blob.get('table_name', ''),
-                'ip': blob.get('ip', ''),
-                'port': blob.get('port', '')
-            })
+            streaming_urls.append(
+                {
+                    "id": blob.get("file", ""),  # Use file as id
+                    "file": blob.get("file", ""),
+                    "streaming_url": url,
+                    "dbms": blob.get("dbms_name", ""),
+                    "table": blob.get("video_table") or blob.get("table_name", ""),
+                    "ip": blob.get("ip", ""),
+                    "port": blob.get("port", ""),
+                }
+            )
             print(f"Created streaming URL: {url}")
-        
+
         print(f"Final streaming_urls: {streaming_urls}")
-        
-        return {
-            "type": "streaming_urls",
-            "data": streaming_urls
-        }
+
+        return {"type": "streaming_urls", "data": streaming_urls}
     except Exception as e:
-        print(f"=== STREAMING ERROR ===")
+        print("=== STREAMING ERROR ===")
         print(f"Error type: {type(e).__name__}")
         print(f"Error message: {str(e)}")
         print(f"Request: {request}")
-        print(f"=== END STREAMING ERROR ===")
-        
+        print("=== END STREAMING ERROR ===")
+
         return {
             "type": "error",
             "data": f"Error constructing streaming URLs: {str(e)}",
             "error_details": {
                 "error_type": type(e).__name__,
                 "error_message": str(e),
-                "request": str(request)
-            }
+                "request": str(request),
+            },
         }
 
 
@@ -554,30 +625,28 @@ def view_blobs(conn: Connection, blobs: dict):
     # print("blobs", blobs['blobs'])
 
     file_list = []
-    for blob in blobs['blobs']:
+    for blob in blobs["blobs"]:
         print("blob", blob)
         # Here you would implement the logic to view the blob
 
         ip_port = f"{blob['ip']}:{blob['port']}"
-        operator_dbms = blob['dbms_name']
-        operator_table = blob.get('video_table') or blob.get('table_name', '')
-        operator_file = blob['file']
+        operator_dbms = blob["dbms_name"]
+        operator_table = blob.get("video_table") or blob.get("table_name", "")
+        operator_file = blob["file"]
         file_list.append(operator_file)
 
         # blobs_dir = "/app/Remote-CLI/djangoProject/static/blobs/current/"
         blobs_dir = "/app/CLI/local-cli-backend/static/"
-        # if not os.path.exists(blobs_dir): 
+        # if not os.path.exists(blobs_dir):
         #     print("Blobs directory does not exist")
-        #     root = __file__.split("CLI")[0] 
-        #     blobs_dir = blobs_dir.replace('/app', root) 
+        #     root = __file__.split("CLI")[0]
+        #     blobs_dir = blobs_dir.replace('/app', root)
         print("IP:Port", ip_port)
 
         print("blobs_dir", blobs_dir)
 
-
         # cmd = f'run client ({ip_port}) file get !!blockchain_file !blockchain_file'
         # cmd = f'run client ({ip_port}) file get !!blobs_dir/{operator_file} !blobs_dir/{operator_file}'
-        
 
         cmd = f"run client ({ip_port}) file get (dbms = blobs_{operator_dbms} and table = {operator_table} and id = {operator_file}) {blobs_dir}{operator_dbms}.{operator_table}.{operator_file}"  # Add file full path and name for the destination on THIS MACHINE
         raw_response = make_request(conn.conn, "POST", cmd)
@@ -591,20 +660,27 @@ def view_blobs(conn: Connection, blobs: dict):
 
         print("raw_response", raw_response)
 
-
     return {"data": file_list}
 
 
+app.include_router(plugins_router)
+
+app.mount(
+    "/official-plugins",
+    StaticFiles(directory=str(PLUGIN_BUILDS_DIR), html=True),
+    "official-plugins",
+)
+
+manager = get_plugin_manager()
+manager.set_app(app)
 
 # streaming
-# info = (dest_type = rest) 
+# info = (dest_type = rest)
 # for streaming — views.py method stream_process
 # uses post
 # cmd: source_url = f"http://{ip}:{port}/?User-Agent=AnyLog/1.23?command=file retrieve where dbms={dbms} and table={table} and id={file} and stream = true"
 
 # build image or video or audio (aka any file) viewer
-
-
 
 
 # http://45.33.110.211:31800

--- a/CLI/local-cli-backend/plugins/base.py
+++ b/CLI/local-cli-backend/plugins/base.py
@@ -1,0 +1,178 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+from uuid import uuid4
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    model_serializer,
+    model_validator,
+)
+from pydantic.alias_generators import to_camel
+
+
+class VersionInfo(BaseModel):
+    major: int = Field(ge=0)
+    minor: int = Field(ge=0)
+    patch: int = Field(ge=0)
+
+    @model_serializer
+    def serialize_model(self) -> str:
+        return str(self)
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_version(cls, v):
+        if isinstance(v, str):
+            major, minor, patch = map(int, v.split("."))
+            return {
+                "major": major,
+                "minor": minor,
+                "patch": patch,
+            }
+        return v
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    def _tuple(self):
+        return (self.major, self.minor, self.patch)
+
+    def __gt__(self, other):
+        if not isinstance(other, VersionInfo):
+            return NotImplemented
+        return self._tuple() > other._tuple()
+
+    def __lt__(self, other):
+        if not isinstance(other, VersionInfo):
+            return NotImplemented
+        return self._tuple() < other._tuple()
+
+    def __eq__(self, other):
+        if not isinstance(other, VersionInfo):
+            return NotImplemented
+        return self._tuple() == other._tuple()
+
+
+class PluginManifest(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    min_py_version: VersionInfo
+    fe_exposed_module: str
+    api_prefix: str
+
+
+class PluginCore(BaseModel):
+    name: str
+    id: str = Field(default=str(uuid4()))
+    slug: str
+    description: str
+    version: VersionInfo
+    manifest: PluginManifest
+
+
+class MarketplacePlugin(BaseModel):
+    core: PluginCore
+    thumbnail: HttpUrl
+    readme_link: HttpUrl
+    download_link: HttpUrl
+    repository_link: HttpUrl
+
+
+class InstalledPlugin(BaseModel):
+    core: PluginCore
+    install_path: Path
+    installed_at: datetime = Field(default_factory=datetime.now)
+
+    def write(self, at_path: Path, file_name: str):
+        at_path.mkdir(exist_ok=True, parents=True)
+        file = Path(at_path) / file_name
+
+        file.write_text(self.model_dump_json())
+
+    @classmethod
+    def load(cls, fp: Path):
+        if not fp.exists() or not fp.is_file():
+            raise FileNotFoundError(f"Path {fp} not found")
+
+        plugin_json_string = fp.read_text()
+        return cls.model_validate_json(plugin_json_string)
+
+class CompletePlugin(BaseModel):
+    core: PluginCore
+
+    install_path: Path
+    installed_at: datetime
+
+    thumbnail: HttpUrl
+    readme_link: HttpUrl
+    download_link: HttpUrl
+    repository_link: HttpUrl
+
+    def write(self, at_path: Path, file_name: str):
+        at_path.mkdir(exist_ok=True, parents=True)
+        file = Path(at_path) / file_name
+
+        file.write_text(self.model_dump_json())
+
+    @classmethod
+    def load(cls, fp: Path):
+        if not fp.exists() or not fp.is_file():
+            raise FileNotFoundError(f"Path {fp} not found")
+
+        plugin_json_string = fp.read_text()
+        return cls.model_validate_json(plugin_json_string)
+
+    def to_installed(self) -> InstalledPlugin:
+        return InstalledPlugin(
+            core=self.core,
+            install_path=self.install_path,
+            installed_at=self.installed_at
+        )
+
+    def to_mkt(self) -> MarketplacePlugin:
+        return MarketplacePlugin(
+            core=self.core,
+            thumbnail=self.thumbnail,
+            readme_link=self.readme_link,
+            download_link=self.download_link,
+            repository_link=self.repository_link,
+        )
+    
+    def flatten(self) -> Dict[str, Any]:
+        return flatten(self.model_dump())
+
+class LivePlugin(BaseModel):
+    installed: InstalledPlugin
+    api_prefix: str | None
+    internal_port: int | None
+    proc_id: int | None
+
+def build_complete_plugin(
+    installed: InstalledPlugin,
+    marketplace: MarketplacePlugin
+) -> CompletePlugin:
+    core = (installed or marketplace).core
+
+    return CompletePlugin(
+        core=core,
+        install_path=installed.install_path,
+        installed_at=installed.installed_at if installed else None,
+
+        thumbnail=marketplace.thumbnail if marketplace else None,
+        readme_link=marketplace.readme_link if marketplace else None,
+        download_link=marketplace.download_link if marketplace else None,
+        repository_link=marketplace.repository_link if marketplace else None,
+    )
+
+def flatten(d: Dict[str, Any]) -> Dict[str, Any]:
+    result = {}
+    for k, v in d.items():
+        if isinstance(v, dict):
+            result.update(flatten(v))
+        else:
+            result[k] = v
+    return result

--- a/CLI/local-cli-backend/plugins/engine.py
+++ b/CLI/local-cli-backend/plugins/engine.py
@@ -1,0 +1,458 @@
+import asyncio
+import importlib.metadata
+import importlib.util
+import json
+import os
+import re
+import sys
+from enum import StrEnum
+from pathlib import Path
+from typing import AsyncGenerator, Dict, List, Optional
+
+import aiofiles
+from psutil import AccessDenied, NoSuchProcess, Process
+
+from plugins.base import CompletePlugin, InstalledPlugin
+from plugins.exceptions import PluginError, PluginNotFoundError, PluginNotRunningError
+
+PLUGINS_PATH = (
+    Path(os.path.dirname(os.path.abspath(__file__))).parent / "official-plugins"
+)
+HOST_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_ANYLOG_API_SPEC = "git+https://github.com/AnyLog-co/AnyLog-API@main"
+_ANYLOG_DIST_NAMES = ("anylog-api", "anylog_api")
+
+
+def _anylog_api_spec_from_host() -> Optional[str]:
+    if importlib.util.find_spec("anylog_api") is None:
+        return None
+
+    for dist_name in _ANYLOG_DIST_NAMES:
+        try:
+            dist = importlib.metadata.distribution(dist_name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+
+        try:
+            direct = json.loads(dist.read_text("direct_url.json"))
+            url = direct.get("url")
+            if url:
+                return url
+        except (FileNotFoundError, OSError, json.JSONDecodeError, KeyError, TypeError) as e:
+            print(f"Failed to load direct_url.json for {dist_name}: {e}")
+            pass
+
+    return None
+
+
+def _resolve_anylog_api_install_spec() -> str:
+    env_spec = os.environ.get("ANYLOG_API_PIP_SPEC", "").strip()
+    if env_spec:
+        return env_spec
+
+    host_spec = _anylog_api_spec_from_host()
+    if host_spec:
+        return host_spec
+
+    return DEFAULT_ANYLOG_API_SPEC
+
+
+async def _install_anylog_api_into_plugin_venv(
+    venv_python: Path, backend_path: Path, log_file
+) -> None:
+    spec = _resolve_anylog_api_install_spec()
+    log_file.write(
+        f"\n[Enging] Installing anylog_api into plugin environment: {spec}\n".encode(
+            "utf-8"
+        )
+    )
+    log_file.flush()
+
+    proc = await asyncio.create_subprocess_exec(
+        "uv",
+        "pip",
+        "install",
+        spec,
+        "--python",
+        str(venv_python),
+        cwd=backend_path,
+        stdout=log_file,
+        stderr=log_file,
+    )
+    if await proc.wait() != 0:
+        raise RuntimeError(
+            f"Failed installing anylog_api ({spec}). "
+            "Set ANYLOG_API_PIP_SPEC to your AnyLog-API wheel or git URL."
+        )
+
+
+class PluginEngine:
+    def __init__(self):
+        self.processes: Dict[str, asyncio.subprocess.Process] = {}
+        self.plugins: Dict[str, InstalledPlugin] = {}
+        self.proc_metrics: Dict[str, Dict[int, Process]] = {}
+
+    def find_local_plugins(self, plugins_path: Path) -> List[CompletePlugin]:
+        local_plugins: List[CompletePlugin] = []
+
+        # print(f"Searching {plugins_path=}")
+        for root, _, files in os.walk(plugins_path):
+            if "plugin_installation.json" in files:
+                file_path = Path(root) / "plugin_installation.json"
+                try:
+                    local_plugins.append(CompletePlugin.load(file_path))
+                except Exception as e:
+                    print(f"Found corrupted plugin install: {file_path}")
+                    print(e)
+                    continue
+
+        return local_plugins
+
+    def get_local_plugin_by_id(
+        self, plugin_id: str, plugins_path: Path
+    ) -> Optional[CompletePlugin]:
+        local_plugins = self.find_local_plugins(plugins_path)
+        for plugin in local_plugins:
+            if plugin.core.slug == plugin_id:
+                return plugin
+        return None
+
+    async def start_plugin(self, installed_plugin: InstalledPlugin, port: int):
+        backend_path = installed_plugin.install_path / "backend"
+        venv_path = backend_path / ".venv"
+
+        bin_dir = "Scripts" if sys.platform == "win32" else "bin"
+        venv_python = venv_path / bin_dir / "python"
+        venv_uvicorn = venv_path / bin_dir / "uvicorn"
+
+        log_path = installed_plugin.install_path / "log.txt"
+        log_file = None
+
+        try:
+            log_file = open(log_path, "ab")
+            if not venv_path.exists():
+                venv_proc = await asyncio.create_subprocess_exec(
+                    "uv",
+                    "venv",
+                    str(venv_path),
+                    "--seed",
+                    cwd=backend_path,
+                )
+                if await venv_proc.wait() != 0:
+                    raise Exception("Failed to create environment for plugin")
+
+            setup_proc = await asyncio.create_subprocess_exec(
+                "uv",
+                "pip",
+                "install",
+                "-r",
+                "requirements.txt",
+                "--python",
+                str(venv_python),
+                cwd=backend_path,
+                stdout=log_file,
+                stderr=log_file,
+            )
+            if await setup_proc.wait() != 0:
+                raise Exception("Failed to install backend dependencies for plugin")
+
+            try:
+                await _install_anylog_api_into_plugin_venv(
+                    venv_python, backend_path, log_file
+                )
+            except RuntimeError as e:
+                raise Exception(str(e)) from e
+
+            env = os.environ.copy()
+            host = str(HOST_BACKEND_ROOT)
+            existing = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = f"{host}:{existing}" if existing else host
+
+            print(f"env pythonpath: {env['PYTHONPATH']}")
+
+            proc = await asyncio.create_subprocess_exec(
+                str(venv_uvicorn),
+                "main:app",
+                "--port",
+                str(port),
+                cwd=backend_path,
+                stdout=log_file,
+                stderr=log_file,
+                env=env,
+            )
+            self.processes[installed_plugin.core.slug] = proc
+            self.plugins[installed_plugin.core.slug] = installed_plugin
+
+            asyncio.create_task(
+                self._watch_plugin(installed_plugin.core.slug, proc, log_file)
+            )
+            return proc
+
+        except Exception as e:
+            if log_file:
+                log_file.close()
+            raise PluginError(f"Unable to start plugin: {e}")
+
+    async def stop_plugin(self, slug: str, timeout: float = 5.0):
+        proc = self.processes.get(slug)
+        if not proc:
+            return
+
+        proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+
+        self.processes.pop(slug, None)
+        self.plugins.pop(slug, None)
+        self.proc_metrics.pop(slug, None)
+
+    async def restart_plugin(self, installed_plugin: InstalledPlugin, port: int):
+        if installed_plugin.core.slug in self.processes:
+            await self.stop_plugin(installed_plugin.core.slug)
+        await self.start_plugin(installed_plugin, port)
+
+    def plugin_running(self, slug: str) -> bool:
+        proc = self.processes.get(slug)
+        if not proc:
+            return False
+        return proc.returncode is None
+
+    async def _watch_plugin(
+        self, slug: str, proc: asyncio.subprocess.Process, log_file
+    ):
+        try:
+            await proc.wait()
+        finally:
+            log_file.close()
+            self.processes.pop(slug, None)
+            self.plugins.pop(slug, None)
+            self.proc_metrics.pop(slug, None)
+
+    def get_plugin_log_path(self, slug: str) -> Path:
+        active_plugin = self.plugins.get(slug)
+        if not active_plugin:
+            print(f"PLUGINS PATH: {PLUGINS_PATH}")
+            installed = self.get_local_plugin_by_id(slug, PLUGINS_PATH)
+            if installed is None:
+                raise PluginNotFoundError(slug)
+            raise PluginNotRunningError(installed.to_installed())
+        return Path(active_plugin.install_path) / "log.txt"
+
+    async def stream_log(self, slug: str) -> AsyncGenerator[Dict, None]:
+        log_path = self.get_plugin_log_path(slug)
+
+        history = await get_last_n_lines(log_path, 50)
+        for line in history:
+            yield {"log": parse_log_line(line), "metrics": None}
+
+        async with aiofiles.open(log_path, mode="r") as f:
+            await f.seek(0, os.SEEK_END)
+            while self.plugin_running(slug):
+                line = await f.readline()
+                if line:
+                    yield {
+                        "log": parse_log_line(line),
+                        "metrics": self.get_metrics(slug),
+                    }
+                else:
+                    yield {"metrics": self.get_metrics(slug), "log": None}
+                    await asyncio.sleep(1)
+
+            yield {"log": "PLUGIN STOPPED", "metrics": None}
+
+    def get_metrics(self, slug: str) -> Optional[Dict[str, float]]:
+        if slug not in self.processes:
+            return None
+
+        try:
+            if slug not in self.proc_metrics:
+                self.proc_metrics[slug] = {}
+
+            plugin_cache = self.proc_metrics[slug]
+            parent_pid = self.processes[slug].pid
+
+            newly_added = set()
+
+            if parent_pid not in plugin_cache:
+                p = Process(parent_pid)
+                p.cpu_percent(interval=None)
+                plugin_cache[parent_pid] = p
+                newly_added.add(parent_pid)
+
+            parent = plugin_cache[parent_pid]
+
+            if not parent.is_running() or parent.status() == "zombie":
+                return None
+
+            try:
+                current_children = parent.children(recursive=True)
+            except (NoSuchProcess, AccessDenied):
+                current_children = []
+
+            all_current_pids = {parent.pid} | {c.pid for c in current_children}
+
+            expired = [pid for pid in plugin_cache if pid not in all_current_pids]
+            for pid in expired:
+                del plugin_cache[pid]
+
+            for child in current_children:
+                if child.pid not in plugin_cache:
+                    child.cpu_percent(interval=None)
+                    plugin_cache[child.pid] = child
+                    newly_added.add(child.pid)
+
+            total_cpu = 0.0
+            total_mem_mb = 0.0
+            total_mem_percent = 0.0
+            total_threads = 0
+
+            for pid, p in plugin_cache.items():
+                if pid in newly_added:
+                    continue
+                try:
+                    total_cpu += p.cpu_percent(interval=None)
+                    mem = p.memory_info()
+                    total_mem_mb += mem.rss
+                    total_mem_percent += p.memory_percent()
+                    total_threads += p.num_threads()
+                except (NoSuchProcess, AccessDenied):
+                    continue
+
+            return {
+                "cpu_percent": round(total_cpu, 2),
+                "memory_mb": round(total_mem_mb / (1024 * 1024), 2),
+                "memory_percent": round(total_mem_percent, 2),
+                "thread_count": total_threads,
+            }
+        except (NoSuchProcess, AccessDenied):
+            return None
+
+
+_engine: PluginEngine | None = None
+
+
+def get_plugin_engine() -> PluginEngine:
+    global _engine
+    if _engine is None:
+        _engine = PluginEngine()
+
+    return _engine
+
+
+async def get_last_n_lines(file_path, n=50):
+    lines = []
+    chunk_size = 1024  # Read 1KB at a time
+
+    async with aiofiles.open(file_path, mode="rb") as f:
+        # Move pointer to the very end of the file
+        await f.seek(0, os.SEEK_END)
+        file_size = await f.tell()
+
+        pointer = file_size
+        buffer = b""
+
+        # Read backwards in chunks
+        while len(lines) < n and pointer > 0:
+            # Determine how much to read (don't go past start of file)
+            step = min(pointer, chunk_size)
+            pointer -= step
+
+            await f.seek(pointer)
+            chunk = await f.read(step)
+
+            # Combine new chunk with previous remainder
+            buffer = chunk + buffer
+            lines = buffer.split(b"\n")
+
+        # We might have read one extra partial line if we didn't hit the start
+        # Grab the last N lines and decode bytes to string
+        result = [line.decode("utf-8", errors="ignore") for line in lines[-n:]]
+        return [line for line in result if line]  # Filter out empty lines
+
+
+class LogLevel(StrEnum):
+    INFO = "INFO"
+    WARN = "WARN"
+    ERROR = "ERROR"
+    DEBUG = "DEBUG"
+    RAW = "RAW"
+
+
+class LogCategory(StrEnum):
+    UVICORN = "UVICORN"
+    APP = "APP"
+    INSTALL = "INSTALL"
+    RAW = "RAW"
+
+
+_UVICORN = re.compile(r"^(INFO|WARNING|ERROR|CRITICAL|DEBUG):\s{5}(.+)$")
+
+_BRACKETED = re.compile(r"^\[([^\]]+)\]\s+(.+)$")
+
+_APP_ERROR = re.compile(r"^[Ee]rror\b", re.IGNORECASE)
+
+_INSTALL = re.compile(r"^(\s*[+\-~]\s+\w|Resolved \d|Installed \d|Audited \d)")
+
+
+def parse_log_line(raw: str) -> dict:
+    line = raw.rstrip()
+
+    m = _UVICORN.match(line)
+    if m:
+        lvl_str, msg = m.group(1), m.group(2)
+        level = {
+            "WARNING": LogLevel.WARN,
+            "CRITICAL": LogLevel.ERROR,
+        }.get(
+            lvl_str,
+            LogLevel(lvl_str)
+            if lvl_str in LogLevel._value2member_map_
+            else LogLevel.INFO,
+        )
+        return {
+            "raw": line,
+            "level": level,
+            "category": LogCategory.UVICORN,
+            "message": msg,
+            "context": None,
+        }
+
+    if _INSTALL.match(line):
+        return {
+            "raw": line,
+            "level": LogLevel.INFO,
+            "category": LogCategory.INSTALL,
+            "message": line.strip(),
+            "context": None,
+        }
+
+    m = _BRACKETED.match(line)
+    if m:
+        ctx, msg = m.group(1), m.group(2)
+        level = LogLevel.ERROR if _APP_ERROR.match(msg) else LogLevel.INFO
+        return {
+            "raw": line,
+            "level": level,
+            "category": LogCategory.APP,
+            "message": msg,
+            "context": ctx,
+        }
+
+    if _APP_ERROR.match(line):
+        level = LogLevel.ERROR
+    elif line.startswith("Warning") or line.startswith("WARN"):
+        level = LogLevel.WARN
+    else:
+        level = LogLevel.RAW
+
+    return {
+        "raw": line,
+        "level": level,
+        "category": LogCategory.RAW,
+        "message": line,
+        "context": None,
+    }

--- a/CLI/local-cli-backend/plugins/exceptions.py
+++ b/CLI/local-cli-backend/plugins/exceptions.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import List, Optional
+
+from plugins.base import InstalledPlugin, MarketplacePlugin, PluginCore
+
+
+class PluginError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class InstallError(PluginError):
+    def __init__(self, message: str, core: PluginCore, install_path: Path):
+        super().__init__(message)
+        self.message = message
+        self.core = core
+        self.install_path = install_path
+
+
+class InvalidPluginStructureError(InstallError):
+    def __init__(
+        self,
+        marketplace_plugin: MarketplacePlugin,
+        install_path: Path,
+        missing: Optional[List[str]] = None,
+    ):
+        message = "Invalid plugin package structure."
+        if missing:
+            message += f" Missing required path: {', '.join(missing)}."
+        super().__init__(message, marketplace_plugin.core, install_path)
+        self.missing = missing if missing else []
+
+
+class PluginNotFoundError(PluginError):
+    def __init__(self, slug: str):
+        super().__init__(f"Plugin '{slug}' not found")
+
+
+class PluginNotRunningError(PluginError):
+    def __init__(self, installed: InstalledPlugin, cause: Optional[str] = None):
+        self.installed = installed
+        base_message = "The plugin is currently not running"
+        if cause:
+            super().__init__(f"{base_message}. {cause}")
+        else:
+            super().__init__(base_message)
+
+
+class PluginAppInitializationError(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/CLI/local-cli-backend/plugins/installer.py
+++ b/CLI/local-cli-backend/plugins/installer.py
@@ -1,0 +1,370 @@
+import asyncio
+import os
+import shutil
+import traceback
+import zipfile
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+import aiofile
+import httpx
+from feature_config_loader import delete_plugin_feature, write_plugin_feature
+from plugins import manager
+from plugins.base import (
+    InstalledPlugin,
+    MarketplacePlugin,
+    PluginCore,
+    build_complete_plugin,
+)
+from plugins.exceptions import InstallError, InvalidPluginStructureError
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _format_step_failure(
+    step: str,
+    plugin_slug: str,
+    plugin_path: Path,
+    exc: Exception,
+    extra: Optional[dict] = None,
+) -> str:
+    details = [
+        f"[plugin-install][error] step={step}",
+        f"plugin={plugin_slug}",
+        f"install_path={plugin_path}",
+        f"error_type={type(exc).__name__}",
+        f"error={exc}",
+        f"cwd={os.getcwd()}",
+        f"path_env={os.environ.get('PATH', '')}",
+    ]
+    if extra:
+        for key, value in extra.items():
+            details.append(f"{key}={value}")
+    details.append("traceback:")
+    details.append(traceback.format_exc())
+    return "\n".join(details)
+
+
+def _log_step_failure(
+    step: str,
+    plugin_slug: str,
+    plugin_path: Path,
+    exc: Exception,
+    extra: Optional[dict] = None,
+):
+    message = _format_step_failure(step, plugin_slug, plugin_path, exc, extra)
+    print(message)
+    try:
+        plugin_path.mkdir(parents=True, exist_ok=True)
+        with open(plugin_path / "install_error.log", "a", encoding="utf-8") as log_file:
+            log_file.write(message + "\n\n")
+    except Exception as log_exc:
+        print(
+            f"[plugin-install][error] Failed writing install_error.log for {plugin_slug}: {log_exc}"
+        )
+
+
+def _require_tool(
+    tool_name: str, plugin_slug: str, plugin_path: Path, plugin_core: PluginCore
+):
+    resolved = shutil.which(tool_name)
+    if resolved:
+        return resolved
+    err = FileNotFoundError(
+        f"Required executable '{tool_name}' was not found in PATH inside runtime environment"
+    )
+    _log_step_failure(
+        step="preflight-runtime-tools",
+        plugin_slug=plugin_slug,
+        plugin_path=plugin_path,
+        exc=err,
+        extra={"missing_tool": tool_name},
+    )
+    raise InstallError(
+        (
+            f"Missing required runtime tool '{tool_name}'. "
+            "Install Node.js/npm in the runtime container to enable plugin frontend builds."
+        ),
+        core=plugin_core,
+        install_path=plugin_path,
+    )
+
+
+async def install_plugin(
+    mkt_plugin: MarketplacePlugin,
+    plugins_path: Path,
+    on_progress: Optional[Callable[[str], Awaitable[None]]],
+) -> InstalledPlugin:
+    loop = asyncio.get_event_loop()
+    slug = mkt_plugin.core.slug
+
+    plugins_basepath = Path(plugins_path)
+    plugins_basepath.mkdir(parents=True, exist_ok=True)
+
+    plugin_path = plugins_basepath.joinpath(slug)
+    plugin_path.mkdir(parents=True, exist_ok=True)
+
+    if on_progress:
+        await on_progress("Downloading plugin contents")
+
+    print(f"Attempting download: {repr(str(mkt_plugin.download_link))}")
+
+    try:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            async with client.stream("GET", str(mkt_plugin.download_link)) as resp:
+                resp.raise_for_status()
+                async with aiofile.async_open(plugin_path / "file.zip", "wb") as f:
+                    async for chunk in resp.aiter_bytes():
+                        await f.write(chunk)
+    except Exception as e:
+        _log_step_failure(
+            step="download",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=e,
+            extra={"download_link": str(mkt_plugin.download_link)},
+        )
+        raise InstallError(
+            "Failed downloading plugin archive",
+            core=mkt_plugin.core,
+            install_path=plugin_path,
+        ) from e
+
+    if on_progress:
+        await on_progress("Extracting plugin contents")
+
+    # with zipfile.ZipFile(plugin_path.joinpath("file.zip"), "r") as z:
+    #     z.extractall(plugin_path)
+    try:
+
+        def extract_zip():
+            with zipfile.ZipFile(plugin_path / "file.zip", "r") as z:
+                z.extractall(plugin_path)
+            os.remove(plugin_path / "file.zip")
+
+        await loop.run_in_executor(None, extract_zip)
+    except Exception as e:
+        _log_step_failure(
+            step="extract",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=e,
+            extra={"zip_path": str(plugin_path / "file.zip")},
+        )
+        raise InstallError(
+            "Failed extracting plugin archive",
+            core=mkt_plugin.core,
+            install_path=plugin_path,
+        ) from e
+
+    if on_progress:
+        await on_progress("Validating plugin structure")
+    backend_path, frontend_path = plugin_path / "backend", plugin_path / "frontend"
+    if not backend_path.exists():
+        err = FileNotFoundError(f"Missing backend directory at '{backend_path}'")
+        _log_step_failure(
+            step="validate-structure",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=err,
+            extra={"missing_path": str(backend_path)},
+        )
+        raise InvalidPluginStructureError(
+            mkt_plugin, plugins_basepath, missing=["backend"]
+        )
+
+    if not frontend_path.exists():
+        err = FileNotFoundError(f"Missing frontend directory at '{frontend_path}'")
+        _log_step_failure(
+            step="validate-structure",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=err,
+            extra={"missing_path": str(frontend_path)},
+        )
+        raise InvalidPluginStructureError(
+            mkt_plugin, plugins_basepath, missing=["frontend"]
+        )
+
+    _require_tool("npm", slug, plugin_path, mkt_plugin.core)
+    _require_tool("npx", slug, plugin_path, mkt_plugin.core)
+
+    # write_plugin_craco(
+    #     slug=mkt_plugin.core.slug,
+    #     entryFileName=mkt_plugin.core.manifest.fe_exposed_module,
+    #     filepath=frontend_path,
+    # )
+
+    if on_progress:
+        await on_progress("Installing plugin UI dependencies")
+
+    fe_build_log = Path(frontend_path / "build.log")
+    try:
+        with open(fe_build_log, "w") as f:
+            install_fe_proc = await asyncio.create_subprocess_exec(
+                "npm",
+                "install",
+                "--legacy-peer-deps",
+                "--yes",
+                # stdout=asyncio.subprocess.DEVNULL,
+                # stderr=asyncio.subprocess.DEVNULL,
+                stdout=f,
+                stderr=f,
+                cwd=frontend_path,
+            )
+            install_term_code = await install_fe_proc.wait()
+
+            if install_term_code != 0:
+                err = RuntimeError(f"npm install exited with code {install_term_code}")
+                _log_step_failure(
+                    step="frontend-npm-install",
+                    plugin_slug=slug,
+                    plugin_path=plugin_path,
+                    exc=err,
+                    extra={
+                        "frontend_path": str(frontend_path),
+                        "build_log": str(fe_build_log),
+                    },
+                )
+                raise InstallError(
+                    "Failed installing plugin UI dependencies",
+                    core=mkt_plugin.core,
+                    install_path=plugin_path,
+                )
+
+            print("Installed plugin frontend dependencies")
+
+            if on_progress:
+                await on_progress("Building plugin UI")
+
+            build_fe_proc = await asyncio.create_subprocess_exec(
+                # "npm",
+                # "run",
+                # "build",
+                "npx",
+                "-y",
+                "vite",
+                "build",
+                stdout=f,
+                stderr=f,
+                # stdout=asyncio.subprocess.DEVNULL,
+                # stderr=asyncio.subprocess.DEVNULL,
+                cwd=frontend_path,
+            )
+            build_term_code = await build_fe_proc.wait()
+
+            if build_term_code != 0:
+                err = RuntimeError(f"vite build exited with code {build_term_code}")
+                _log_step_failure(
+                    step="frontend-build",
+                    plugin_slug=slug,
+                    plugin_path=plugin_path,
+                    exc=err,
+                    extra={
+                        "frontend_path": str(frontend_path),
+                        "build_log": str(fe_build_log),
+                    },
+                )
+                raise InstallError(
+                    "Failed building plugin",
+                    core=mkt_plugin.core,
+                    install_path=plugin_path,
+                )
+
+            print("Built plugin frontend")
+            if on_progress:
+                await on_progress("Build plugin UI components")
+    except InstallError:
+        raise
+    except Exception as e:
+        _log_step_failure(
+            step="frontend-tooling",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=e,
+            extra={
+                "frontend_path": str(frontend_path),
+                "build_log": str(fe_build_log),
+            },
+        )
+        raise InstallError(
+            "Failed running frontend tooling (npm/npx)",
+            core=mkt_plugin.core,
+            install_path=plugin_path,
+        ) from e
+
+    if on_progress:
+        await on_progress("Finishing up")
+
+    # shutil.rmtree(Path(frontend_path / "node_modules"))
+    try:
+        await loop.run_in_executor(None, shutil.rmtree, frontend_path / "node_modules")
+    except Exception as e:
+        _log_step_failure(
+            step="cleanup-node-modules",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=e,
+            extra={"node_modules_path": str(frontend_path / "node_modules")},
+        )
+        raise InstallError(
+            "Failed during plugin cleanup",
+            core=mkt_plugin.core,
+            install_path=plugin_path,
+        ) from e
+
+    installed = InstalledPlugin(core=mkt_plugin.core, install_path=plugin_path)
+
+    try:
+        complete_plugin = build_complete_plugin(installed, mkt_plugin)
+        complete_plugin.write(plugin_path, "plugin_installation.json")
+    except Exception as e:
+        _log_step_failure(
+            step="write-install-manifest",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=e,
+            extra={"manifest_path": str(plugin_path / "plugin_installation.json")},
+        )
+        raise InstallError(
+            "Failed writing plugin installation metadata",
+            core=mkt_plugin.core,
+            install_path=plugin_path,
+        ) from e
+
+    try:
+        # enable_plugin_feature(plugin.core.slug)
+        write_plugin_feature(mkt_plugin.core)
+    except Exception as e:
+        _log_step_failure(
+            step="feature-config-update",
+            plugin_slug=slug,
+            plugin_path=plugin_path,
+            exc=e,
+        )
+        raise InstallError(
+            "Failed updating feature config for plugin",
+            core=mkt_plugin.core,
+            install_path=plugin_path,
+        ) from e
+
+    if on_progress:
+        await on_progress("Completed")
+
+    return installed
+    # return installed
+
+
+async def uninstall_plugin(installed: InstalledPlugin):
+    if manager.get_plugin_engine().plugin_running(installed.core.slug):
+        await manager.get_plugin_engine().stop_plugin(installed.core.slug)
+    plugin_path = installed.install_path
+    if not plugin_path.exists():
+        raise FileNotFoundError(f"Plugin '{installed.core.slug}' not installed")
+    shutil.rmtree(plugin_path, ignore_errors=True)
+
+    dev_dir = installed.install_path.parent
+    if dev_dir.exists() and len(os.listdir(dev_dir)) == 0:
+        shutil.rmtree(dev_dir, ignore_errors=True)
+
+    delete_plugin_feature(installed.core.slug)

--- a/CLI/local-cli-backend/plugins/manager.py
+++ b/CLI/local-cli-backend/plugins/manager.py
@@ -1,0 +1,220 @@
+from plugins.base import CompletePlugin
+import asyncio
+import os
+import socket
+from asyncio import Task
+from pathlib import Path
+from typing import Dict, List, Union
+
+import httpx
+import websockets
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from starlette.requests import Request
+from starlette.websockets import WebSocket, WebSocketDisconnect
+
+from plugins.base import InstalledPlugin, LivePlugin, MarketplacePlugin
+from plugins.engine import get_plugin_engine
+from plugins.exceptions import (
+    PluginAppInitializationError,
+)
+from plugins.installer import install_plugin
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+# OFFICIAL_PLUGINS_PATH = Path(BASE_DIR) / "official-plugins"
+
+OFFICIAL_PLUGINS_PATH = (
+    Path(os.path.dirname(os.path.abspath(__file__))).parent / "official-plugins"
+)
+
+if not OFFICIAL_PLUGINS_PATH.exists():
+    OFFICIAL_PLUGINS_PATH.mkdir(parents=True, exist_ok=True)
+
+
+class PluginManager:
+    def __init__(self):
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=5.0))
+        self._engine = get_plugin_engine()
+        self._app: FastAPI | None = None
+        self._redirect_mappings: Dict[str, int] = {}
+        self._install_tasks: Dict[str, Task] = {}
+        self._install_progress: Dict[str, list[str]] = {}
+
+    def set_app(self, app: FastAPI):
+        self._app = app
+
+    def _alloc_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("", 0))
+            return s.getsockname()[1]
+
+    def get_redirect(self, slug: str) -> Union[int, None]:
+        return self._redirect_mappings[slug]
+
+    def set_redirect(self, prefix: str, port: int):
+        self._redirect_mappings[prefix] = port
+        self._register_route(prefix, port)
+        print(f"Enabled redirect '{prefix}' -> {port}")
+
+    async def start_plugin(self, installed: InstalledPlugin):
+        if not self._app:
+            raise PluginAppInitializationError(
+                "No FastAPI app registered within plugin manager"
+            )
+
+        port = self._alloc_port()
+
+        await self._engine.start_plugin(installed_plugin=installed, port=port)
+        self.set_redirect(installed.core.slug.replace("/", "%2F"), port)
+        self.set_redirect(installed.core.manifest.api_prefix.strip("/"), port)
+
+        # return LivePlugin(installed=installed, api_prefix=self._redirect_mappings.get(installed.core.slug, installed.core.slug), internal_port=port, proc_id=proc.pid)
+
+    def get_local_plugins(self) -> List[CompletePlugin]:
+        return self._engine.find_local_plugins(OFFICIAL_PLUGINS_PATH)
+
+    def get_live_plugins(self) -> List[LivePlugin]:
+        return []
+        installed_plugins = self.get_installed_plugins()
+        live_plugins: List[LivePlugin] = []
+
+        for installed in installed_plugins:
+            proc = self._engine.processes.get(installed.core.slug)
+            port = self.get_redirect(installed.core.slug)
+            if proc and port:
+                live_plugins.append(
+                    LivePlugin(
+                        installed=installed,
+                        api_prefix=self.get_redirect(installed.core.slug),
+                        internal_port=port,
+                        proc_id=proc.pid,
+                    )
+                )
+
+        return live_plugins
+
+    def _register_route(self, prefix: str, port: int):
+        clean_prefix = prefix.replace("/", "-")
+
+        async def proxy_handler(scope, receive, send):
+            # path = scope["path"] if scope["path"].startswith("/") else f"/{scope['path']}"
+            path = scope["path"]
+            qs = scope.get("query_string", b"").decode()
+            url = f"ws://127.0.0.1:{port}{path}"
+            if qs:
+                url = f"{url}?{qs}"
+
+            print(f"[proxy] type={scope['type']} port={port} path={path!r} url={url}")
+
+            if scope["type"] == "websocket":
+                ws = WebSocket(scope, receive, send)
+                await ws.accept()
+                url = f"ws://127.0.0.1:{port}{path}"
+                if qs:
+                    url = f"{url}?{qs}"
+                try:
+                    async with websockets.connect(url) as upstream:
+
+                        async def from_client():
+                            while True:
+                                message = await ws.receive()
+                                if message["type"] == "websocket.disconnect":
+                                    await upstream.close()
+                                    return
+                                if "bytes" in message and message["bytes"]:
+                                    await upstream.send(message["bytes"])
+                                elif "text" in message and message["text"]:
+                                    await upstream.send(message["text"])
+
+                        async def from_upstream():
+                            async for message in upstream:
+                                if isinstance(message, bytes):
+                                    await ws.send_bytes(message)
+                                else:
+                                    await ws.send_text(message) #type:ignore
+
+                        await asyncio.gather(from_client(), from_upstream())
+                except (websockets.ConnectionClosed, WebSocketDisconnect):
+                    pass
+
+            else:
+                request = Request(scope, receive)
+                url = f"http://127.0.0.1:{port}{path}"
+                if qs:
+                    url = f"{url}?{qs}"
+                rp_req = self._client.build_request(
+                    method=request.method,
+                    url=url,
+                    headers={
+                        k: v for k, v in request.headers.items() if k.lower() != "host"
+                    },
+                    content=request.stream(),
+                )
+                rp_resp = await self._client.send(rp_req, stream=True)
+                response = StreamingResponse(
+                    rp_resp.aiter_raw(),
+                    status_code=rp_resp.status_code,
+                    headers=dict(rp_resp.headers),
+                    background=rp_resp.aclose, #type:ignore
+                )
+                await response(scope, receive, send)
+
+        if self._app:
+            self._app.mount(f"/{clean_prefix}", app=proxy_handler)
+        else:
+            raise PluginAppInitializationError(
+                "No FastAPI app registered within plugin manager"
+            )
+
+    async def stop_plugin(self, slug: str):
+        if not self._app:
+            raise PluginAppInitializationError(
+                "No FastAPI app registered within plugin manager"
+            )
+
+        await self._engine.stop_plugin(slug=slug)
+
+        # start_plugin registers encoded slug and manifest api_prefix — remove both.
+        self._redirect_mappings.pop(slug.replace("/", "%2F"), None)
+        self._redirect_mappings.pop(slug, None)
+        for p in self.get_local_plugins():
+            if p.core.slug == slug:
+                prefix = (p.core.manifest.api_prefix or "").strip("/")
+                if prefix:
+                    self._redirect_mappings.pop(prefix, None)
+                break
+
+    def install_and_track(self, plugin: MarketplacePlugin, plugins_path: Path) -> Task:
+        slug = plugin.core.slug
+        self._install_progress[slug] = []
+
+        async def on_progress(message: str):
+            self._install_progress[slug].append(message)
+
+        task = asyncio.create_task(
+            install_plugin(plugin, OFFICIAL_PLUGINS_PATH, on_progress=on_progress)
+        )
+
+        self._install_tasks[plugin.core.slug] = task
+        return task
+
+    def get_install_tasks(self) -> Dict[str, Task]:
+        return self._install_tasks
+
+    def get_install_progress(self, slug: str) -> List[str]:
+        return self._install_progress.get(slug, [])
+    
+    def clear_install_task(self, slug: str):
+        self._install_tasks.pop(slug, None)
+        self._install_progress.pop(slug, None)
+
+
+_manager: PluginManager | None = None
+
+
+def get_plugin_manager() -> PluginManager:
+    global _manager
+    if _manager is None:
+        _manager = PluginManager()
+
+    return _manager

--- a/CLI/local-cli-backend/plugins_router.py
+++ b/CLI/local-cli-backend/plugins_router.py
@@ -1,0 +1,263 @@
+import os
+from asyncio import Task
+from pathlib import Path
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, Field, model_validator
+
+import plugins
+import plugins.exceptions
+from decorators import wrap_sse_stream
+from feature_config_loader import (
+    disable_plugin_feature,
+    enable_plugin_feature,
+    resolve_plugin_enabled_from_config,
+)
+from plugins.base import InstalledPlugin, MarketplacePlugin
+from plugins.engine import get_plugin_engine
+from plugins.installer import uninstall_plugin
+from plugins.loader import get_plugin_order
+from plugins.manager import get_plugin_manager
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+OFFICIAL_PLUGINS_PATH = Path(BASE_DIR) / "official-plugins"
+
+if not OFFICIAL_PLUGINS_PATH.exists():
+    OFFICIAL_PLUGINS_PATH.mkdir(parents=True, exist_ok=True)
+
+plugins_router = APIRouter(prefix="/plugins", tags=["feature-config", "plugins"])
+manager = get_plugin_manager()
+engine = get_plugin_engine()
+
+
+def get_plugin_order_config() -> dict:
+    plugins_dir = os.path.join(BASE_DIR, "plugins")
+    plugin_order = get_plugin_order(plugins_dir)
+    return {
+        "plugin_order": plugin_order if plugin_order else [],
+        "has_custom_order": plugin_order is not None,
+    }
+
+
+class InstallRequest(BaseModel):
+    plugin: MarketplacePlugin
+    path: str = Field(default=str(OFFICIAL_PLUGINS_PATH))
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_plugin(cls, data):
+        if "plugin" not in data:
+            plugin_fields = {"name", "id", "version", "download_link"}
+            if plugin_fields.issubset(data.keys()):
+                data = dict(data)
+                data["plugin"] = {k: data.pop(k) for k in plugin_fields}
+        return data
+
+
+class ModificationRequest(BaseModel):
+    slug: str
+
+
+@plugins_router.get("/order")
+def get_plugin_order_endpoint():
+    return get_plugin_order_config()
+
+
+@plugins_router.get("")
+def get_main():
+    return RedirectResponse("/plugins/", 301)
+
+
+@plugins_router.get("/")
+async def return_plugins():
+    """Installed plugins for the host UI; includes ``enabled`` from feature_config (do not omit disabled)."""
+    local_plugins = manager.get_local_plugins()
+    return [
+        {
+            **p.flatten(),
+            "remoteUrl": f"/official-plugins/{p.core.slug}/frontend/dist/remoteEntry.js",
+            "enabled": resolve_plugin_enabled_from_config(p.core.slug),
+        }
+        for p in local_plugins
+    ]
+
+
+@plugins_router.post("/install")
+async def post_install_plugin(req: InstallRequest):
+    print(f"Installing: {req.plugin.core.slug} from {req.plugin.download_link}")
+    try:
+        slug = req.plugin.core.slug
+        curr_installs = manager.get_install_tasks()
+        install_task: Task = curr_installs.get(slug)
+
+        if install_task is not None:
+            if not install_task.done():
+                raise HTTPException(
+                    409, detail="Install already in progress for this plugin"
+                )
+            try:
+                result = install_task.result()
+            except plugins.exceptions.InstallError as e:
+                raise HTTPException(400, detail=e.message) from e
+            except Exception as e:
+                raise HTTPException(400, detail=str(e)) from e
+            if isinstance(result, InstalledPlugin):
+                raise HTTPException(400, detail="Plugin already installed")
+
+        manager.install_and_track(req.plugin, OFFICIAL_PLUGINS_PATH)
+        return {"slug": slug, "status": "installing"}
+
+    except plugins.exceptions.InvalidPluginStructureError as e:
+        raise HTTPException(400, f"Malformed plugin: {e.message}")
+    except plugins.exceptions.InstallError as e:
+        raise HTTPException(400, detail=e.message) from e
+
+
+@plugins_router.get("/status/{slug:path}")
+async def get_install_status(slug: str):
+    # slug = slug.replace("_", "/")
+    task = manager.get_install_tasks().get(slug)
+    if not task:
+        return {"error": "No install task found"}, 404
+
+    progress = manager.get_install_progress(slug)
+
+    if not task.done():
+        return {"status": "installing", "progress": progress}
+    if task.cancelled():
+        return {"status": "cancelled", "progress": progress}
+    exc = task.exception()
+    if exc:
+        return {"status": "failed", "error": str(exc), "progress": progress}
+    result: InstalledPlugin = task.result()
+    return {
+        "status": "complete",
+        "install_path": str(result.install_path),
+        "progress": progress,
+    }
+
+
+@plugins_router.post("/uninstall")
+async def post_uninstall_plugin(req: ModificationRequest):
+    try:
+        installed = manager.get_local_plugins()
+        for plugin in installed:
+            if plugin.core.slug == req.slug:
+                print(f"Uninstalling matched plugin: {req.slug}")
+                await uninstall_plugin(plugin.to_installed())
+
+                # config = load_feature_config()
+                # del config["plugins"][plugin.core.slug]
+                # write_feature_config(config)
+
+                manager.clear_install_task(req.slug)
+                return
+
+        print(f"Couldn't find {req.slug} to uninstall")
+        raise HTTPException(400, f"{req.slug} not installed")
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except FileNotFoundError as e:
+        raise HTTPException(400, str(e))
+
+
+@plugins_router.patch("/enable")
+async def enable_plugin(req: ModificationRequest):
+    try:
+        installed = manager.get_local_plugins()
+        for plugin in installed:
+            if plugin.core.slug == req.slug:
+                print("Starting plugin from engine")
+                await manager.start_plugin(plugin.to_installed())
+                enable_plugin_feature(req.slug)
+                return {"slug": req.slug, "status": "enabled", "enabled": True}
+
+        raise HTTPException(404, detail=f"No installed plugin named: {req.slug}")
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(400, detail=str(e)) from e
+
+
+@plugins_router.patch("/disable")
+async def disable_plugin(req: ModificationRequest):
+    try:
+        local_plugins = manager.get_local_plugins()
+        for plugin in local_plugins:
+            if plugin.core.slug == req.slug:
+                print("Stopping plugin from engine")
+                await manager.stop_plugin(req.slug)
+                disable_plugin_feature(req.slug)
+                return {"slug": req.slug, "status": "disabled", "enabled": False}
+        raise HTTPException(404, detail=f"No installed plugin with slug: {req.slug}")
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(400, detail=str(e)) from e
+
+
+@plugins_router.get("/installed")
+async def list_plugins(req: Request):
+    try:
+        plugins = manager.get_local_plugins()
+        return plugins
+    except Exception:
+        raise HTTPException(500, "Faild finding plugins")
+
+
+@plugins_router.get("/live")
+async def get_live_plugins(req: Request):
+    try:
+        live = manager.get_live_plugins()
+        return live
+    except Exception:
+        raise HTTPException(500, "Failed gathering live plugins")
+
+
+@plugins_router.get("/logs")
+@wrap_sse_stream
+async def stream_plugin_log(req: Request, slug: str = Query(...)):
+    if "/" not in slug:
+        raise HTTPException(400, detail="Invalid plugin slug")
+
+    try:
+        gen = engine.stream_log(slug)
+
+        first_val = await gen.__anext__()
+
+        async def yield_logs():
+            yield first_val
+            async for item in gen:
+                yield item
+
+        return yield_logs()
+    except (
+        plugins.exceptions.PluginNotFoundError,
+        plugins.exceptions.PluginNotRunningError,
+    ) as e:
+
+        async def yield_error(e):
+            yield {"event": "error", "data": str(e)}
+
+        return yield_error(e)
+
+
+class Redirect(BaseModel):
+    prefix: str
+    port: int
+
+
+class ConfigurationRequest(BaseModel):
+    redirects: List[Redirect]
+
+
+@plugins_router.post("/configuration/redirect")
+async def update_configuration(req: ConfigurationRequest):
+    for redirect in req.redirects:
+        manager.set_redirect(redirect.prefix, redirect.port)

--- a/CLI/local-cli-backend/reqs.txt
+++ b/CLI/local-cli-backend/reqs.txt
@@ -1,3 +1,5 @@
+aiofile==3.11.1
+aiofiles==25.1.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.11.16
 aiosignal==1.3.2
@@ -34,6 +36,7 @@ pipreqs==0.4.13
 pluggy==1.5.0
 postgrest==1.0.1
 propcache==0.3.1
+psutil==7.2.2
 pydantic==2.10.6
 pydantic_core==2.27.2
 Pygments==2.19.1

--- a/CLI/local-cli-fe-full/package-lock.json
+++ b/CLI/local-cli-fe-full/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@module-federation/vite": "^1.14.5",
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.8",
         "@testing-library/dom": "^10.4.0",
@@ -25,8 +26,10 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^6.30.0",
         "recharts": "^3.7.0",
+        "remark-gfm": "^4.0.1",
         "tslib": "^2.8.1",
         "web-vitals": "^2.1.4",
         "xterm": "^5.3.0",
@@ -34,7 +37,9 @@
         "zustand": "^5.0.11"
       },
       "devDependencies": {
-        "@vitejs/plugin-react": "^4.3.4",
+        "@vitejs/plugin-react": "^4.7.0",
+        "react-router-dom": "^6.30.0",
+        "typescript": "^6.0.3",
         "vite": "^5.4.11",
         "vitest": "^2.1.8"
       }
@@ -936,6 +941,134 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@module-federation/dts-plugin": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.5.0.tgz",
+      "integrity": "sha512-q7KDhJ5tn2HrUV7uMuh/L3TaaztUosE+4LAb90sxx0pPPqWRwlpBpxu1REubv5BWXmU1K/Ozn14u6jRbjLVaGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/managers": "2.5.0",
+        "@module-federation/sdk": "2.5.0",
+        "@module-federation/third-party-dts-extractor": "2.5.0",
+        "adm-zip": "0.5.10",
+        "ansi-colors": "4.1.3",
+        "isomorphic-ws": "5.0.0",
+        "node-schedule": "2.1.1",
+        "undici": "7.24.7",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.9.0 || ^5.0.0",
+        "vue-tsc": ">=1.0.24"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/error-codes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.5.0.tgz",
+      "integrity": "sha512-sq05/8Gp3csy1nr2/f76K3vLy0/xRqVtP71ibGy8BiLg7h1UxWN7G4EwAKSrPZ4FnsERGeFlIszg5Z+MqlwhFg==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/managers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.5.0.tgz",
+      "integrity": "sha512-9b5mU/7OYbKrYUJmhZ1kkfeJCZqR7qX6/FWp+oOfZMzUynN7Rb41dwoUs3TdnOKzbZ3CCwtZ2WsR4pF9ZNvuJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/sdk": "2.5.0",
+        "find-pkg": "2.0.0"
+      }
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.5.0.tgz",
+      "integrity": "sha512-dOc7pFEf8aruHBk5hoJLnvwkCa5ELT78q3o9dqcdaa/TT74X5z0FT0BsaGaRBPcse/iP6czK3fWd7RLv5ZKP5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/runtime-core": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.5.0.tgz",
+      "integrity": "sha512-STmhQ3c6/hunba2FMP6GrHazXU/8GuN7Gk4dOkWNRpnqYIoD8Wx4MNl76j3HdCzBESC7uSMXTniksVaM1+xxyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "2.5.0",
+        "@module-federation/sdk": "2.5.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.5.0.tgz",
+      "integrity": "sha512-ScU22XDyV77l50njjzewMpMlNN1CYo0tHS1D6iy+vNKWrHGq8DWVB0vwG8dmvx/WZ4uq+sXgUsQet17MoKsfZw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-fetch": "^2.7.0 || ^3.3.2"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@module-federation/third-party-dts-extractor": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.5.0.tgz",
+      "integrity": "sha512-5di43LGk2ies86Cj8QyzYr540Ijc+nyPqYziyFotL6Pparnu+uf3b3ERfEyQfBmEcyGk1MpitQIO2J3bd9BcNw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-pkg": "2.0.0",
+        "resolve": "1.22.8"
+      }
+    },
+    "node_modules/@module-federation/third-party-dts-extractor/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@module-federation/vite": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@module-federation/vite/-/vite-1.16.2.tgz",
+      "integrity": "sha512-XjfReMlQWe+i0SCmkbhrqIuo7WEGIoWH4AsvBQ9gLBa+DxA4qnygJrL6kHi7T1z7EVNRhTTysTHm4ezXGkvr5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/dts-plugin": "2.5.0",
+        "@module-federation/runtime": "2.5.0",
+        "@module-federation/sdk": "2.5.0",
+        "es-module-lexer": "^2.0.0",
+        "estree-walker": "^3.0.3",
+        "pathe": "^2.0.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@module-federation/vite/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.3.9",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.9.tgz",
@@ -1219,6 +1352,7 @@
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
       "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -1800,11 +1934,52 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/pako": {
@@ -1832,16 +2007,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
@@ -1858,11 +2023,23 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1936,16 +2113,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@vitest/mocker/node_modules/magic-string": {
@@ -2044,6 +2211,24 @@
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
       "license": "MIT"
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2097,6 +2282,16 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/base64-arraybuffer": {
@@ -2228,6 +2423,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2243,6 +2448,46 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -2264,6 +2509,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -2277,18 +2532,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-bundle": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.48.0.tgz",
-      "integrity": "sha512-e1WrUdQaoOaRfcvIe9iZynVWwmuvzxJOMrRzTj4YIyw6PGqAe1fjTK/9bh3OeHXY0muase+JoTHN83w1TucnJQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -2308,6 +2551,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/css-line-break": {
@@ -2476,6 +2731,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2493,6 +2761,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dexie": {
@@ -2572,6 +2853,12 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "license": "MIT"
+    },
     "node_modules/es-toolkit": {
       "version": "1.45.1",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
@@ -2643,6 +2930,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "license": "MIT",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2652,6 +2970,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-png": {
       "version": "6.4.0",
@@ -2669,6 +2993,30 @@
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
+    },
+    "node_modules/find-file-up": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-2.0.1.tgz",
+      "integrity": "sha512-qVdaUhYO39zmh28/JLQM5CoYN9byEOKEH4qfa8K1eNV17W0UUMJ9WgbR/hHFH+t5rcl+6RTb5UC7ck/I+uRkpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-dir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-2.0.0.tgz",
+      "integrity": "sha512-WgZ+nKbELDa6N3i/9nrHeNznm+lY3z4YfhDDWgW+5P0pdmMj26bxaxU11ookgY3NyP9GC7HvZ9etp0jRFqGEeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "find-file-up": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/find-root": {
       "version": "1.1.0",
@@ -2710,6 +3058,36 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+      "license": "MIT",
+      "dependencies": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2720,6 +3098,46 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -2736,6 +3154,28 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/html2canvas": {
       "version": "1.4.1",
@@ -2776,6 +3216,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2790,6 +3242,30 @@
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
       "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2810,6 +3286,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/js-tokens": {
@@ -2887,6 +3419,22 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==",
+      "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2916,6 +3464,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -2924,6 +3481,861 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -2966,6 +4378,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-schedule": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
+      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^4.2.0",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2993,6 +4419,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -3009,6 +4460,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-parse": {
@@ -3122,6 +4582,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3177,6 +4647,33 @@
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -3204,6 +4701,7 @@
       "version": "6.30.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
       "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.2"
@@ -3219,6 +4717,7 @@
       "version": "6.30.3",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.2",
@@ -3326,7 +4825,74 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -3352,6 +4918,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+      "license": "MIT",
+      "dependencies": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3386,6 +4965,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sorted-array-functions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
+      "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3403,6 +4988,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stackback": {
@@ -3429,6 +5024,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -3439,6 +5048,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylis": {
@@ -3529,6 +5156,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3540,6 +5187,20 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "license": "Unlicense"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/typeson": {
       "version": "5.18.2",
@@ -3594,6 +5255,102 @@
         "node": ">=10"
       }
     },
+    "node_modules/undici": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3642,6 +5399,34 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -3892,6 +5677,18 @@
         "node": ">=10.4"
       }
     },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3907,6 +5704,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xterm": {
@@ -3969,6 +5787,16 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/CLI/local-cli-fe-full/package.json
+++ b/CLI/local-cli-fe-full/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@module-federation/vite": "^1.14.5",
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.8",
     "@testing-library/dom": "^10.4.0",
@@ -20,16 +21,20 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^6.30.0",
+    "recharts": "^3.7.0",
+    "remark-gfm": "^4.0.1",
+    "tslib": "^2.8.1",
     "web-vitals": "^2.1.4",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
-    "zustand": "^5.0.11",
-    "recharts": "^3.7.0",
-    "tslib": "^2.8.1"
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.4",
+    "@vitejs/plugin-react": "^4.7.0",
+    "react-router-dom": "^6.30.0",
+    "typescript": "^6.0.3",
     "vite": "^5.4.11",
     "vitest": "^2.1.8"
   },

--- a/CLI/local-cli-fe-full/scripts/generateFederationExposes.js
+++ b/CLI/local-cli-fe-full/scripts/generateFederationExposes.js
@@ -1,0 +1,43 @@
+import { readdirSync, statSync } from "fs";
+import { join, relative, extname } from "path";
+
+const FOLDERS = ["components", "services", "styles", "utils"];
+const EXTENSIONS = [".js", ".jsx", ".ts", ".tsx", ".css"];
+const SRC = new URL("../src", import.meta.url).pathname;
+
+const walk = (dir, base = dir) => {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      results.push(...walk(full, base));
+    } else if (EXTENSIONS.includes(extname(entry))) {
+      results.push(full);
+    }
+  }
+  return results;
+};
+
+export const generateExposes = () => {
+  const exposes = {};
+
+  for (const folder of FOLDERS) {
+    const folderPath = join(SRC, folder);
+    let files;
+    try {
+      files = walk(folderPath);
+    } catch {
+      console.warn(`[federation-exposes] Skipping missing folder: ${folder}`);
+      continue;
+    }
+
+    for (const file of files) {
+      const rel = relative(SRC, file); // e.g. "components/Button.js"
+      const key = `./${rel}`; // e.g. "./components/Button.js"
+      exposes[key] = `./src/${rel}`; // e.g. "./src/components/Button.js"
+    }
+  }
+
+  return exposes;
+};

--- a/CLI/local-cli-fe-full/scripts/hostFederationPlugins.js
+++ b/CLI/local-cli-fe-full/scripts/hostFederationPlugins.js
@@ -1,0 +1,27 @@
+import { generateExposes } from "./generateFederationExposes.js";
+
+export const hostFederationPlugin = () => {
+  let exposes;
+
+  return {
+    name: "host-federation-exposes",
+    config(config) {
+      exposes = generateExposes();
+      console.log(
+        `[federation-exposes] Exposing ${Object.keys(exposes).length} modules`,
+      );
+
+      const fedPlugin = config.plugins
+        ?.flat()
+        .find((p) => p?.name === "module-federation");
+      if (fedPlugin?._options) {
+        fedPlugin._options.exposes = {
+          ...fedPlugin._options.exposes,
+          ...exposes,
+        };
+      }
+
+      return config;
+    },
+  };
+};

--- a/CLI/local-cli-fe-full/src/App.js
+++ b/CLI/local-cli-fe-full/src/App.js
@@ -1,22 +1,27 @@
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import Dashboard from './pages/Dashboard';
-import './styles/App.css'; // Import your global styles here
+import React from "react";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from "react-router-dom";
+import Dashboard from "./pages/Dashboard";
+import "./styles/App.css"; // Import your global styles here
+import { HostServicesProvider } from "./context/HostServicesProvider";
 
 // npm i -D react-router-dom ------> NEED TO INSTALL REACT-ROUTER-DOM TO WORK PROPERLY
 function App() {
   return (
-    <Router>
-      <Routes>
-        {/* Protected Dashboard Route */}
-        <Route
-          path="/dashboard/*"
-          element={<Dashboard />}
-        />
-        {/* Default Route */}
-        <Route path="*" element={<Navigate to="/dashboard/client" />} />
-      </Routes>
-    </Router>
+    <HostServicesProvider>
+      <Router>
+        <Routes>
+          {/* Protected Dashboard Route */}
+          <Route path="/dashboard/*" element={<Dashboard />} />
+          {/* Default Route */}
+          <Route path="*" element={<Navigate to="/dashboard/client" />} />
+        </Routes>
+      </Router>
+    </HostServicesProvider>
   );
 }
 

--- a/CLI/local-cli-fe-full/src/bootstrap.js
+++ b/CLI/local-cli-fe-full/src/bootstrap.js
@@ -1,0 +1,34 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
+
+const _originalEntries = Object.entries;
+const _originalKeys = Object.keys;
+const _originalValues = Object.values;
+
+Object.entries = function (obj) {
+  if (obj == null) return [];
+  return _originalEntries.call(Object, obj);
+};
+Object.keys = function (obj) {
+  if (obj == null) return [];
+  return _originalKeys.call(Object, obj);
+};
+Object.values = function (obj) {
+  if (obj == null) return [];
+  return _originalValues.call(Object, obj);
+};
+
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals();

--- a/CLI/local-cli-fe-full/src/components/Sidebar.js
+++ b/CLI/local-cli-fe-full/src/components/Sidebar.js
@@ -1,73 +1,106 @@
 // src/components/Sidebar.js
-import React, { useState, useEffect } from 'react';
-import { NavLink } from 'react-router-dom';
-import { getPluginSidebarItems, initializePluginOrder } from '../plugins/loader';
-import { 
-  initializeFeatureConfig, 
-  isFeatureEnabled, 
-  isPluginEnabled 
-} from '../services/featureConfig';
-import { getLicenseInfo } from '../services/api';
-import '../styles/Sidebar.css';
+import React, { useState, useEffect } from "react";
+import { NavLink } from "react-router-dom";
+import {
+  getPluginSidebarItems,
+  initializePluginOrder,
+  refreshPluginPages,
+} from "../plugins/loader";
+import {
+  fetchFeatureConfig,
+  initializeFeatureConfig,
+  isFeatureEnabled,
+  isPluginEnabled,
+} from "../services/featureConfig";
+import { getLicenseInfo } from "../services/api";
+import "../styles/Sidebar.css";
 
 const Sidebar = ({ selectedNode }) => {
   const [pluginItems, setPluginItems] = useState(() => getPluginSidebarItems());
   const [enabledFeatures, setEnabledFeatures] = useState(new Set());
   const [enabledPlugins, setEnabledPlugins] = useState(new Set());
+  const [federatedPlugins, setFederatedPlugins] = useState([]);
   const [configLoaded, setConfigLoaded] = useState(false);
+  const [featureConfig, setFeatureConfig] = useState([]);
+
   const [license, setLicense] = useState(null);
-  
-  // Feature configuration mapping
-  const featureConfig = [
-    { path: 'client', name: 'Client', featureKey: 'client' },
-    { path: 'monitor', name: 'Monitor', featureKey: 'monitor' },
-    { path: 'policies', name: 'Policies', featureKey: 'policies' },
-    { path: 'adddata', name: 'Add Data', featureKey: 'adddata' },
-    { path: 'viewfiles', name: 'View Files', featureKey: 'viewfiles' },
-    { path: 'sqlquery', name: 'SQL Query', featureKey: 'sqlquery' },
-    { path: 'blockchain', name: 'Blockchain Manager', featureKey: 'blockchain' },
-    { path: 'presets', name: 'Presets', featureKey: 'presets' },
-    { path: 'bookmarks', name: 'Bookmarks', featureKey: 'bookmarks' },
-    { path: 'security', name: 'Security (Anylog)', featureKey: 'security' },
-  ];
-  
-  // Fetch feature config and plugin order on mount
+
   useEffect(() => {
-    const loadConfig = async () => {
-      // Initialize both configs in parallel
-      await Promise.all([
-        initializeFeatureConfig(),
-        initializePluginOrder()
-      ]);
-      
-      // Check which features are enabled
+    const fetchConfigOnLoad = async () => {
+      const config = await fetchFeatureConfig();
+
+      if (config) {
+        const transformedFeatures = Object.entries(config.features || {}).map(
+          ([key]) => ({
+            path: key,
+            name: key[0].toUpperCase() + key.slice(1),
+            featureKey: key,
+          }),
+        );
+        setFeatureConfig(transformedFeatures);
+      }
+
+      await Promise.all([initializeFeatureConfig(), initializePluginOrder()]);
+
       const enabled = new Set();
-      for (const feature of featureConfig) {
-        if (await isFeatureEnabled(feature.featureKey)) {
-          enabled.add(feature.featureKey);
+      for (const featureKey of Object.keys(config.features || {})) {
+        if (await isFeatureEnabled(featureKey)) {
+          enabled.add(featureKey);
         }
       }
       setEnabledFeatures(enabled);
-      
-      // Check which plugins are enabled and filter plugin items
+
       const allPluginItems = getPluginSidebarItems();
       const enabledPluginItems = [];
       const enabledPluginSet = new Set();
-      
+
       for (const plugin of allPluginItems) {
         if (await isPluginEnabled(plugin.path)) {
           enabledPluginItems.push(plugin);
           enabledPluginSet.add(plugin.path);
         }
       }
-      
+
       setEnabledPlugins(enabledPluginSet);
       setPluginItems(enabledPluginItems);
       setConfigLoaded(true);
     };
-    
-    loadConfig();
+
+    fetchConfigOnLoad();
   }, []);
+
+  // Load federated plugins separately
+  useEffect(() => {
+    const loadFederated = async () => {
+      try {
+        const allPages = await refreshPluginPages();
+        const federated = Object.values(allPages)
+          .filter((p) => p._source === "federation")
+          .map((p) => ({
+            path: p.path,
+            name: p.name,
+            icon: p.icon,
+          }));
+        setFederatedPlugins(federated);
+      } catch (err) {
+        console.error("[Sidebar] Failed to load federated plugins:", err);
+      }
+    };
+
+    loadFederated();
+    window.addEventListener("anylog:plugins-changed", loadFederated);
+    const interval = setInterval(loadFederated, 30000);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("anylog:plugins-changed", loadFederated);
+    };
+  }, []);
+
+  const visibleFeatures = featureConfig.filter((f) =>
+    enabledFeatures.has(f.featureKey),
+  );
+
+  const visiblePlugins = pluginItems.filter((p) => enabledPlugins.has(p.path));
 
   useEffect(() => {
     if (!selectedNode) {
@@ -76,48 +109,55 @@ const Sidebar = ({ selectedNode }) => {
     }
     getLicenseInfo({ connectInfo: selectedNode }).then(setLicense);
   }, [selectedNode]);
-  
-  // Filter features based on config
-  const visibleFeatures = featureConfig.filter(feature => 
-    enabledFeatures.has(feature.featureKey)
-  );
-  
-  // Filter plugins based on config
-  const visiblePlugins = pluginItems.filter(plugin => 
-    enabledPlugins.has(plugin.path)
-  );
-  
+
   return (
     <nav className="sidebar">
       {visibleFeatures.map((feature) => (
-        <NavLink 
+        <NavLink
           key={feature.path}
-          to={feature.path} 
-          className={({ isActive }) => isActive ? 'active' : ''}
+          to={feature.path}
+          className={({ isActive }) => (isActive ? "active" : "")}
         >
           {feature.name}
         </NavLink>
       ))}
-      
-      {/* Plugin Navigation - Auto-loaded and filtered */}
+
       {configLoaded && visiblePlugins.length > 0 && (
         <div className="plugin-section">
           {visiblePlugins.map((plugin) => (
-            <NavLink 
+            <NavLink
               key={plugin.path}
-              to={plugin.path} 
-              className={({ isActive }) => isActive ? 'active' : ''}
+              to={plugin.path}
+              className={({ isActive }) => (isActive ? "active" : "")}
             >
-              {plugin.icon && `${plugin.icon} `}{plugin.name}
+              {plugin.icon && `${plugin.icon} `}
+              {plugin.name}
+            </NavLink>
+          ))}
+        </div>
+      )}
+
+      {federatedPlugins.length > 0 && (
+        <div className="installed-plugin-section">
+          {federatedPlugins.map((plugin) => (
+            <NavLink
+              key={plugin.path}
+              to={plugin.path}
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              {plugin.icon && `${plugin.icon} `}
+              {plugin.name}
             </NavLink>
           ))}
         </div>
       )}
 
       <div className="sidebar-version">
-        <NavLink to="about" className="sidebar-about-link">About</NavLink>
+        <NavLink to="about" className="sidebar-about-link">
+          About
+        </NavLink>
         <span className="sidebar-licensee">
-          Licensee: {license?.company ?? '—'}
+          Licensee: {license?.company ?? "—"}
         </span>
       </div>
     </nav>

--- a/CLI/local-cli-fe-full/src/context/HostServicesContext.js
+++ b/CLI/local-cli-fe-full/src/context/HostServicesContext.js
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+export const HostServicesContext = createContext(null);
+
+export const useHost = () => {
+  const ctx = useContext(HostServicesContext);
+  if (!ctx) throw new Error(
+    '[useHost] Must be used inside HostServicesProvider. ' +
+    'Ensure the plugin is mounted within the host app.'
+  );
+  return ctx;
+};
+
+export const useHostServices   = () => useHost().services;
+export const useHostUtils      = () => useHost().utils;
+export const useHostComponents = () => useHost().components;

--- a/CLI/local-cli-fe-full/src/context/HostServicesProvider.js
+++ b/CLI/local-cli-fe-full/src/context/HostServicesProvider.js
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import { HostServicesContext } from './HostServicesContext';
+
+const servicesModules = import.meta.glob('../services/**/*.js', { eager: true });
+const utilsModules = import.meta.glob('../utils/**/*.js', { eager: true });
+const componentModules = import.meta.glob('../components/**/*.js', { eager: true });
+
+const splitModulePath = (filePath, baseFolder) =>
+  filePath
+    .replace(`../${baseFolder}/`, '')
+    .replace(/\.js$/, '')
+    .split('/');
+
+const assignPathValue = (target, pathParts, value) => {
+  let cursor = target;
+  pathParts.forEach((segment, index) => {
+    const isLeaf = index === pathParts.length - 1;
+    if (isLeaf) {
+      cursor[segment] = value;
+      return;
+    }
+    if (!cursor[segment] || typeof cursor[segment] !== 'object') {
+      cursor[segment] = {};
+    }
+    cursor = cursor[segment];
+  });
+};
+
+const buildNamespace = (modules, baseFolder, selector) => {
+  const namespace = {};
+  Object.entries(modules).forEach(([filePath, moduleRef]) => {
+    const pathParts = splitModulePath(filePath, baseFolder);
+    assignPathValue(namespace, pathParts, selector(moduleRef));
+  });
+  return namespace;
+};
+
+export const HostServicesProvider = ({ children }) => {
+  const services = useMemo(
+    () => buildNamespace(servicesModules, 'services', (mod) => mod),
+    [],
+  );
+
+  const utils = useMemo(
+    () => buildNamespace(utilsModules, 'utils', (mod) => mod),
+    [],
+  );
+
+  const components = useMemo(
+    () =>
+      buildNamespace(
+        componentModules,
+        'components',
+        (mod) => mod.default ?? mod,
+      ),
+    [],
+  );
+
+  const value = useMemo(() => ({
+
+    services,
+    utils,
+    components,
+
+  }), [services, utils, components]);
+
+  return (
+    <HostServicesContext.Provider value={value}>
+      {children}
+    </HostServicesContext.Provider>
+  );
+};

--- a/CLI/local-cli-fe-full/src/index.js
+++ b/CLI/local-cli-fe-full/src/index.js
@@ -1,17 +1,1 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
-
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+import("./bootstrap");

--- a/CLI/local-cli-fe-full/src/pages/Dashboard.js
+++ b/CLI/local-cli-fe-full/src/pages/Dashboard.js
@@ -1,137 +1,199 @@
-import React, { useState, useEffect } from 'react';
-import { Routes, Route } from 'react-router-dom';
-import Sidebar from '../components/Sidebar';
-import TopBar from '../components/TopBar';
-import Client from './Client';
-import Monitor from './Monitor';
-import Policies from './Policies';
-import AddData from './AddData';
-import UserProfile from './UserProfile';
-import ViewFiles from './ViewFiles';
-import Presets from './Presets';
-import Bookmarks from './Bookmarks';
-import SqlQueryGenerator from './SqlQueryGenerator';
-import BlockchainManager from './BlockchainManager';
-import About from './About';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  Suspense,
+} from "react";
+import { Routes, Route } from "react-router-dom";
+import Sidebar from "../components/Sidebar";
+import TopBar from "../components/TopBar";
+import Client from "./Client";
+import Monitor from "./Monitor";
+import Policies from "./Policies";
+import AddData from "./AddData";
+import UserProfile from "./UserProfile";
+import ViewFiles from "./ViewFiles";
+import Presets from "./Presets";
+import Bookmarks from "./Bookmarks";
+import SqlQueryGenerator from "./SqlQueryGenerator";
+import BlockchainManager from "./BlockchainManager";
+import About from "./About";
 
 // Import plugin loader
-import { getPluginPages } from '../plugins/loader';
+import {
+  getPluginPages,
+  refreshPluginPages,
+  initializePluginOrder,
+} from "../plugins/loader";
 // Import feature config
 import {
   initializeFeatureConfig,
   isFeatureEnabled,
   isPluginEnabled,
-} from '../services/featureConfig';
+  invalidateFeatureConfig,
+} from "../services/featureConfig";
 
-import PolicyGeneratorPage from './Security';
+import PolicyGeneratorPage from "./Security";
 // import Presets from './Presets';
-import '../styles/Dashboard.css'; // dashboard-specific styles
-import { getBookmarks } from '../services/file_auth';
+import "../styles/Dashboard.css"; // dashboard-specific styles
+import { getBookmarks } from "../services/file_auth";
+
+import PluginErrorBoundary from "../plugins/marketplace/PluginErrorBoundary";
+
+const PluginMountGate = ({ children }) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  if (!mounted) return null;
+  return children;
+};
+
+const FEATURE_ROUTES = [
+  { path: "client", component: Client, featureKey: "client" },
+  { path: "monitor", component: Monitor, featureKey: "monitor" },
+  { path: "policies", component: Policies, featureKey: "policies" },
+  { path: "adddata", component: AddData, featureKey: "adddata" },
+  { path: "viewfiles", component: ViewFiles, featureKey: "viewfiles" },
+  { path: "sqlquery", component: SqlQueryGenerator, featureKey: "sqlquery" },
+  {
+    path: "blockchain",
+    component: BlockchainManager,
+    featureKey: "blockchain",
+  },
+  { path: "presets", component: Presets, featureKey: "presets" },
+  { path: "bookmarks", component: Bookmarks, featureKey: "bookmarks" },
+  { path: "security", component: PolicyGeneratorPage, featureKey: "security" },
+];
 
 const Dashboard = () => {
   // Load plugin pages
-  const pluginPages = getPluginPages();
+  const [pluginPages, setPluginPages] = useState(() => getPluginPages());
 
   // Feature configuration state
   const [enabledFeatures, setEnabledFeatures] = useState(new Set());
   const [enabledPlugins, setEnabledPlugins] = useState(new Set());
   const [configLoaded, setConfigLoaded] = useState(false);
 
+  const isLoadingRef = useRef(false);
+
   // Load initial state from localStorage
   const [nodes, setNodes] = useState(() => {
-    const savedNodes = localStorage.getItem('dashboard-nodes');
+    const savedNodes = localStorage.getItem("dashboard-nodes");
     return savedNodes ? JSON.parse(savedNodes) : [];
   });
 
   const [selectedNode, setSelectedNode] = useState(() => {
-    const savedSelectedNode = localStorage.getItem('dashboard-selected-node');
+    const savedSelectedNode = localStorage.getItem("dashboard-selected-node");
     return savedSelectedNode || null;
   });
 
   const [restoredFromStorage, setRestoredFromStorage] = useState(false);
 
-  // Feature configuration mapping
-  const featureRoutes = [
-    { path: 'client', component: Client, featureKey: 'client' },
-    { path: 'monitor', component: Monitor, featureKey: 'monitor' },
-    { path: 'policies', component: Policies, featureKey: 'policies' },
-    { path: 'adddata', component: AddData, featureKey: 'adddata' },
-    { path: 'viewfiles', component: ViewFiles, featureKey: 'viewfiles' },
-    { path: 'sqlquery', component: SqlQueryGenerator, featureKey: 'sqlquery' },
-    {
-      path: 'blockchain',
-      component: BlockchainManager,
-      featureKey: 'blockchain',
-    },
-    { path: 'presets', component: Presets, featureKey: 'presets' },
-    { path: 'bookmarks', component: Bookmarks, featureKey: 'bookmarks' },
-    {
-      path: 'security',
-      component: PolicyGeneratorPage,
-      featureKey: 'security',
-    },
-  ];
+  const loadPluginsAndConfig = useCallback(async () => {
+    if (isLoadingRef.current) return;
+    isLoadingRef.current = true;
 
-  // Load feature configuration on mount
-  useEffect(() => {
-    const loadConfig = async () => {
+    try {
+      // installs update /feature-config on the server; drop stale cache
+      invalidateFeatureConfig();
+      const freshPages = await refreshPluginPages();
+      console.log("[Dashboard] freshPages:", Object.keys(freshPages));
+      console.log("[Dashboard] pluginEnabled checks:");
+      for (const pluginName of Object.keys(freshPages)) {
+        const enabled = await isPluginEnabled(pluginName);
+        console.log(`  ${pluginName} → ${enabled}`);
+      }
+      setPluginPages((prev) => {
+        const prevKeys = Object.keys(prev).sort().join(",");
+        const nextKeys = Object.keys(freshPages).sort().join(",");
+        return prevKeys === nextKeys ? prev : freshPages;
+      });
+
       await initializeFeatureConfig();
 
-      // Check which features are enabled
       const enabled = new Set();
-      for (const feature of featureRoutes) {
-        if (await isFeatureEnabled(feature.featureKey)) {
-          enabled.add(feature.featureKey);
+      for (const route of FEATURE_ROUTES) {
+        if (await isFeatureEnabled(route.featureKey)) {
+          enabled.add(route.featureKey);
         }
       }
       setEnabledFeatures(enabled);
 
-      // Check which plugins are enabled
+      const { getEnabledPlugins } = await import("../services/featureConfig");
+      const enabledInConfig = await getEnabledPlugins();
+
       const enabledPluginSet = new Set();
-      for (const [pluginName] of Object.entries(pluginPages)) {
-        if (await isPluginEnabled(pluginName)) {
+      for (const [pluginName, plugin] of Object.entries(freshPages)) {
+        const slug = plugin._raw?.slug;
+        const id = plugin._raw?.id;
+
+        if (
+          enabledInConfig.has(pluginName) ||
+          enabledInConfig.has(slug) ||
+          enabledInConfig.has(id)
+        ) {
           enabledPluginSet.add(pluginName);
         }
       }
+
       setEnabledPlugins(enabledPluginSet);
       setConfigLoaded(true);
-    };
-
-    loadConfig();
+    } finally {
+      isLoadingRef.current = false;
+    }
   }, []);
 
   // Debug logging
-  console.log('Dashboard - selectedNode:', selectedNode);
-  console.log('Dashboard - nodes:', nodes);
+  console.log("Dashboard - selectedNode:", selectedNode);
+  console.log("Dashboard - nodes:", nodes);
   console.log(
-    'Dashboard - localStorage nodes:',
-    localStorage.getItem('dashboard-nodes'),
+    "Dashboard - localStorage nodes:",
+    localStorage.getItem("dashboard-nodes"),
   );
   console.log(
-    'Dashboard - localStorage selectedNode:',
-    localStorage.getItem('dashboard-selected-node'),
+    "Dashboard - localStorage selectedNode:",
+    localStorage.getItem("dashboard-selected-node"),
   );
+
+  useEffect(() => {
+    initializePluginOrder();
+    loadPluginsAndConfig();
+  }, [loadPluginsAndConfig]);
+
+  useEffect(() => {
+    window.addEventListener("anylog:plugins-changed", loadPluginsAndConfig);
+    return () =>
+      window.removeEventListener(
+        "anylog:plugins-changed",
+        loadPluginsAndConfig,
+      );
+  }, [loadPluginsAndConfig]);
 
   // Save nodes to localStorage whenever they change
   useEffect(() => {
-    localStorage.setItem('dashboard-nodes', JSON.stringify(nodes));
+    localStorage.setItem("dashboard-nodes", JSON.stringify(nodes));
   }, [nodes]);
 
   // Save selectedNode to localStorage whenever it changes
   useEffect(() => {
     if (selectedNode) {
-      localStorage.setItem('dashboard-selected-node', selectedNode);
-      console.log('Saved selectedNode to localStorage:', selectedNode);
+      localStorage.setItem("dashboard-selected-node", selectedNode);
+      console.log("Saved selectedNode to localStorage:", selectedNode);
     } else {
-      localStorage.removeItem('dashboard-selected-node');
-      console.log('Removed selectedNode from localStorage');
+      localStorage.removeItem("dashboard-selected-node");
+      console.log("Removed selectedNode from localStorage");
     }
   }, [selectedNode]);
 
   // Ensure selectedNode is in nodes list if it exists
   useEffect(() => {
     if (selectedNode && !nodes.includes(selectedNode)) {
-      console.log('Selected node not in nodes list, adding it:', selectedNode);
+      console.log("Selected node not in nodes list, adding it:", selectedNode);
       setNodes((prevNodes) => [...prevNodes, selectedNode]);
     }
   }, [selectedNode, nodes]);
@@ -139,8 +201,8 @@ const Dashboard = () => {
   // Show restoration message if data was loaded from localStorage
   useEffect(() => {
     const hasStoredData =
-      localStorage.getItem('dashboard-nodes') ||
-      localStorage.getItem('dashboard-selected-node');
+      localStorage.getItem("dashboard-nodes") ||
+      localStorage.getItem("dashboard-selected-node");
     if (hasStoredData) {
       setRestoredFromStorage(true);
       // Auto-hide the message after 3 seconds
@@ -176,11 +238,11 @@ const Dashboard = () => {
 
   // Utility function to clear all stored data
   const clearStoredData = () => {
-    localStorage.removeItem('dashboard-nodes');
-    localStorage.removeItem('dashboard-selected-node');
+    localStorage.removeItem("dashboard-nodes");
+    localStorage.removeItem("dashboard-selected-node");
     setNodes([]);
     setSelectedNode(null);
-    console.log('Cleared all stored dashboard data');
+    console.log("Cleared all stored dashboard data");
   };
 
   // Adds a new node (if valid and not already in the list)
@@ -207,8 +269,6 @@ const Dashboard = () => {
     }
   };
 
-
-
   return (
     <div className="dashboard-container">
       <TopBar
@@ -226,41 +286,41 @@ const Dashboard = () => {
         <div className="dashboard-main">
           <Routes>
             {/* Core Feature Routes - Filtered by feature config */}
-            {featureRoutes
-              .filter((route) => enabledFeatures.has(route.featureKey))
-              .map((route) => {
-                if (route.path === 'bookmarks') {
-                  return (
-                    <Route
-                      key={route.path}
-                      path={route.path}
-                      element={
-                        <route.component
-                          node={selectedNode}
-                          onSelectNode={(node) => {
-                            console.log('Selecting node from bookmarks:', node);
-                            // Add node to nodes list if not already present
-                            if (node && !nodes.includes(node)) {
-                              console.log('Adding new node to list:', node);
-                              setNodes((prevNodes) => [...prevNodes, node]);
-                            }
-                            // Set as selected node
-                            setSelectedNode(node);
-                            console.log('Selected node set to:', node);
-                          }}
-                        />
-                      }
-                    />
-                  );
-                }
+            {FEATURE_ROUTES.filter((route) =>
+              enabledFeatures.has(route.featureKey),
+            ).map((route) => {
+              if (route.path === "bookmarks") {
                 return (
                   <Route
                     key={route.path}
                     path={route.path}
-                    element={<route.component node={selectedNode} />}
+                    element={
+                      <route.component
+                        node={selectedNode}
+                        onSelectNode={(node) => {
+                          console.log("Selecting node from bookmarks:", node);
+                          // Add node to nodes list if not already present
+                          if (node && !nodes.includes(node)) {
+                            console.log("Adding new node to list:", node);
+                            setNodes((prevNodes) => [...prevNodes, node]);
+                          }
+                          // Set as selected node
+                          setSelectedNode(node);
+                          console.log("Selected node set to:", node);
+                        }}
+                      />
+                    }
                   />
                 );
-              })}
+              }
+              return (
+                <Route
+                  key={route.path}
+                  path={route.path}
+                  element={<route.component node={selectedNode} />}
+                />
+              );
+            })}
 
             {/* User Profile - Always available */}
             <Route
@@ -275,10 +335,10 @@ const Dashboard = () => {
                 <About
                   key={
                     selectedNode
-                      ? typeof selectedNode === 'string'
+                      ? typeof selectedNode === "string"
                         ? selectedNode
                         : JSON.stringify(selectedNode)
-                      : 'no-node'
+                      : "no-node"
                   }
                   node={selectedNode}
                 />
@@ -288,17 +348,27 @@ const Dashboard = () => {
             {/* Plugin Routes - Auto-loaded and filtered by feature config */}
             {configLoaded &&
               Object.entries(pluginPages)
-                .filter(([pluginName]) => enabledPlugins.has(pluginName))
+                .filter(([name]) => enabledPlugins.has(name))
                 .map(([key, plugin]) => (
                   <Route
                     key={key}
                     path={plugin.path}
                     element={
-                      <React.Suspense
-                        fallback={<div>Loading {plugin.name}...</div>}
-                      >
-                        <plugin.component node={selectedNode} />
-                      </React.Suspense>
+                      <PluginMountGate key={location.pathname}>
+                        <PluginErrorBoundary>
+                          <div className="dashboard-plugin-frame">
+                            <Suspense
+                              fallback={
+                                <div style={{ padding: 32 }}>
+                                  Loading {plugin.name}…
+                                </div>
+                              }
+                            >
+                              <plugin.component node={selectedNode} />
+                            </Suspense>
+                          </div>
+                        </PluginErrorBoundary>
+                      </PluginMountGate>
                     }
                   />
                 ))}
@@ -307,10 +377,10 @@ const Dashboard = () => {
             <Route
               path="*"
               element={(() => {
-                if (enabledFeatures.has('client')) {
+                if (enabledFeatures.has("client")) {
                   return <Client node={selectedNode} />;
                 }
-                const firstEnabled = featureRoutes.find((r) =>
+                const firstEnabled = FEATURE_ROUTES.find((r) =>
                   enabledFeatures.has(r.featureKey),
                 );
                 if (firstEnabled) {

--- a/CLI/local-cli-fe-full/src/plugins/anylogmcp/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/anylogmcp/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/calculator/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/calculator/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/devContext.js
@@ -1,0 +1,68 @@
+import * as hostApi from "../services/api";
+
+const DEV_CONTEXT_KEY = "__ANYLOG_PLUGIN_HOST_CONTEXT__";
+
+// Remove { eager: true } — these are now () => import(...) factories
+const hostServiceModules = import.meta.glob("../services/**/*.js");
+const hostComponentModules = import.meta.glob("../components/**/*.js");
+const hostUtilModules = import.meta.glob("../utils/**/*.js");
+
+const toModuleName = (path) =>
+  path.split("/").pop().replace(/\.(jsx?|tsx?)$/, "");
+
+const collectHostNamespace = async (modules) => {
+  const namespace = {};
+  await Promise.all(
+    Object.entries(modules).map(async ([path, load]) => {
+      const mod = await load();
+      const moduleName = toModuleName(path);
+      namespace[moduleName] = mod?.default ?? mod;
+      Object.entries(mod || {}).forEach(([exportName, value]) => {
+        if (exportName === "default") return;
+        if (!(exportName in namespace)) {
+          namespace[exportName] = value;
+        }
+      });
+    })
+  );
+  return namespace;
+};
+
+const createDefaultDevContext = async () => ({
+  services: {
+    ...(await collectHostNamespace(hostServiceModules)),
+    api: hostApi,
+  },
+  utils: await collectHostNamespace(hostUtilModules),
+  components: await collectHostNamespace(hostComponentModules),
+});
+
+export const initializeDevContext = async (overrides = {}) => {
+  const existing = globalThis[DEV_CONTEXT_KEY] || {};
+  const defaults = await createDefaultDevContext();
+  const merged = {
+    ...defaults,
+    ...existing,
+    ...overrides,
+    services: {
+      ...defaults.services,
+      ...(existing.services || {}),
+      ...(overrides.services || {}),
+    },
+    utils: {
+      ...defaults.utils,
+      ...(existing.utils || {}),
+      ...(overrides.utils || {}),
+    },
+    components: {
+      ...defaults.components,
+      ...(existing.components || {}),
+      ...(overrides.components || {}),
+    },
+  };
+  globalThis[DEV_CONTEXT_KEY] = merged;
+  return merged;
+};
+
+export const getDevContext = () => initializeDevContext();
+export const getHostApi = async () => (await getDevContext()).services.api;

--- a/CLI/local-cli-fe-full/src/plugins/grafana/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/grafana/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/loader.js
+++ b/CLI/local-cli-fe-full/src/plugins/loader.js
@@ -1,35 +1,56 @@
-// Fully Automatic Frontend Plugin Loader
-// Auto-discovers plugin pages by scanning the plugins directory
+const _origCreate = document.createElement.bind(document);
+document.createElement = function (tag, opts) {
+  const el = _origCreate(tag, opts);
+  if (typeof tag === "string" && tag.toLowerCase() === "script") {
+    el.crossOrigin = "anonymous";
+    el.type = "module";
+  }
+  return el;
+};
 
-import React from 'react';
-import { isPluginEnabled } from '../services/featureConfig';
+import React from "react";
+import * as ReactDom from "react-dom";
+import * as ReactJsxRuntime from "react/jsx-runtime";
+import * as tslibModule from "tslib";
+import { initializeDevContext } from "./devContext";
 
-// Cache for plugin order from backend
+const API_URL =
+  window._env_?.VITE_API_URL ||
+  (window.location.port === "8000" || window.location.port === ""
+    ? window.location.origin
+    : "http://localhost:8000");
+
+initializeDevContext();
+
+// ─────────────────────────────────────────────
+// Cache
+// ─────────────────────────────────────────────
+
+export const federationCache = new Map();
+
 let cachedPluginOrder = null;
 let orderFetchPromise = null;
 
-// Fetch plugin order from backend
+// ─────────────────────────────────────────────
+// Plugin order
+// ─────────────────────────────────────────────
+
 const fetchPluginOrder = async () => {
-  if (cachedPluginOrder !== null) {
-    return cachedPluginOrder;
-  }
-  
-  if (orderFetchPromise) {
-    return orderFetchPromise;
-  }
-  
+  if (cachedPluginOrder !== null) return cachedPluginOrder;
+  if (orderFetchPromise) return orderFetchPromise;
+
   orderFetchPromise = (async () => {
     try {
-      const API_URL = window._env_?.VITE_API_URL || import.meta.env.VITE_API_URL || "http://localhost:8080";
-      const response = await fetch(`${API_URL}/plugins/order`);
-      if (response.ok) {
-        const data = await response.json();
+      const res = await fetch(`${API_URL}/plugins/order`);
+      if (res.ok) {
+        const data = await res.json();
         cachedPluginOrder = data.plugin_order || [];
         return cachedPluginOrder;
       }
-    } catch (error) {
-      console.warn('Failed to fetch plugin order:', error);
+    } catch (err) {
+      console.warn("[PluginLoader] order fetch failed:", err);
     }
+
     cachedPluginOrder = [];
     return cachedPluginOrder;
   })();
@@ -37,166 +58,381 @@ const fetchPluginOrder = async () => {
   return orderFetchPromise;
 };
 
-// Sort plugins according to order config
+// ─────────────────────────────────────────────
+// Utils
+// ─────────────────────────────────────────────
+
 const sortPluginsByOrder = (plugins, order) => {
-  if (!order || order.length === 0) {
-    return Object.keys(plugins).sort().map(key => ({ key, plugin: plugins[key] }));
+  if (!plugins || typeof plugins !== "object") return [];
+
+  if (!order?.length) {
+    return Object.keys(plugins)
+      .sort()
+      .map((key) => ({ key, plugin: plugins[key] }));
   }
 
   const ordered = [];
   const remaining = new Set(Object.keys(plugins));
 
-  for (const pluginName of order) {
-    if (plugins[pluginName]) {
-      ordered.push({ key: pluginName, plugin: plugins[pluginName] });
-      remaining.delete(pluginName);
+  for (const name of order) {
+    if (plugins[name]) {
+      ordered.push({ key: name, plugin: plugins[name] });
+      remaining.delete(name);
     }
   }
 
-  const remainingSorted = Array.from(remaining).sort();
-  for (const pluginName of remainingSorted) {
-    ordered.push({ key: pluginName, plugin: plugins[pluginName] });
+  for (const name of Array.from(remaining).sort()) {
+    ordered.push({ key: name, plugin: plugins[name] });
   }
 
   return ordered;
 };
 
-// Auto-discover plugin pages using Vite's import.meta.glob
-// Uses eager loading so modules are already available — no dynamic re-import needed
+const formatPluginName = (name) =>
+  name
+    .replace(/([A-Z])/g, " $1")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[-_]/g, " ")
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+
+// ─────────────────────────────────────────────
+// LOCAL plugins (Vite)
+// ─────────────────────────────────────────────
+
 export const discoverPluginPages = () => {
   const pluginPages = {};
+  const modules = import.meta.glob("./*/*Page.js", { eager: true });
 
-  const modules = import.meta.glob('./*/**Page.js', { eager: true });
-
-  Object.entries(modules).forEach(([modulePath, module]) => {
+  Object.entries(modules).forEach(([path, mod]) => {
     try {
-      const pathParts = modulePath.split('/');
-      const pluginName = pathParts[1];
+      const parts = path.split("/");
+      const pluginName = parts[1];
 
       if (pluginPages[pluginName]) return;
 
-      const metadata = module.pluginMetadata || {};
-      const PageComponent = module.default;
+      const PageComponent = mod.default;
+      const metadata = mod.pluginMetadata || {};
 
-      if (!PageComponent) {
-        console.warn(`Plugin ${pluginName} has no default export, skipping.`);
-        return;
-      }
+      if (!PageComponent) return;
 
       pluginPages[pluginName] = {
         component: PageComponent,
         path: pluginName,
-        name: metadata.name || formatPluginName(pluginName),
-        icon: metadata.icon || null
+        name: metadata.name || pluginName,
+        icon: metadata.icon || null,
+        _source: "local",
       };
-    } catch (error) {
-      console.warn(`Failed to load plugin from ${modulePath}:`, error);
+    } catch (err) {
+      console.warn("[PluginLoader] local load failed:", path, err);
     }
   });
 
   return pluginPages;
 };
 
-// Helper function to format plugin name (fallback if metadata not provided)
-const formatPluginName = (pluginName) => {
-  const words = pluginName
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(word => word.length > 0);
+// ─────────────────────────────────────────────
+// Federation loader
+// ─────────────────────────────────────────────
 
-  return words
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+const resolveRemoteUrl = (remoteUrl) =>
+  remoteUrl.startsWith("http") ? remoteUrl : `${API_URL}${remoteUrl}`;
+
+const registeredRemotes = new Set();
+
+const normalizeExposedModule = (feExposedModule) => {
+  if (!feExposedModule) return "./PluginApp";
+  const normalized = `./${String(feExposedModule)
+    .replace(/^\.\//, "")
+    .replace(/\.js$/i, "")}`;
+  if (normalized === "./CliPage") return "./PluginApp";
+  return normalized;
 };
 
-// Get plugin pages for routing (sorted by plugin order)
+const buildExposeCandidates = (exposedModule) => {
+  const primary = normalizeExposedModule(exposedModule);
+  const candidates = [primary];
+  if (primary !== "./PluginApp") candidates.push("./PluginApp");
+  return candidates;
+};
+
+/** Backend serves plugin CSS under API_URL; host may run on another origin (e.g. Vite :5173). */
+const apiOrigin = () => {
+  try {
+    return new URL(API_URL).origin;
+  } catch {
+    return window.location.origin;
+  }
+};
+
+/**
+ * The host never loads a remote's index.html, only remoteEntry.js — so Vite's normal <link
+ * stylesheet> tags from the build are skipped. Chunk-level CSS injection also sometimes fails
+ * for federated exposes. Fetch index.html next to remoteEntry and mirror its stylesheets.
+ */
+const injectStylesheetsFromRemoteIndexHtml = async (remoteEntryAbsoluteUrl) => {
+  const base = remoteEntryAbsoluteUrl.replace(
+    /\/remoteEntry\.js(\?.*)?$/i,
+    "/",
+  );
+  const indexUrl = `${base}index.html`;
+  const origin = apiOrigin();
+
+  try {
+    const res = await fetch(indexUrl, { cache: "no-store" });
+    if (!res.ok) return;
+
+    const html = await res.text();
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const links = doc.querySelectorAll('link[rel="stylesheet"][href]');
+
+    links.forEach((node) => {
+      const raw = node.getAttribute("href");
+      if (!raw) return;
+
+      let absolute;
+      if (/^https?:\/\//i.test(raw)) {
+        absolute = raw;
+      } else if (raw.startsWith("/")) {
+        absolute = `${origin}${raw}`;
+      } else {
+        absolute = new URL(raw, indexUrl).href;
+      }
+
+      const already = [
+        ...document.querySelectorAll('link[rel="stylesheet"]'),
+      ].some((el) => el.href === absolute);
+      if (already) return;
+
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = absolute;
+      link.crossOrigin = "anonymous";
+      link.setAttribute("data-mf-remote-entry-css", remoteEntryAbsoluteUrl);
+      document.head.appendChild(link);
+    });
+  } catch (err) {
+    console.warn(
+      "[PluginLoader] Could not inject styles from remote index.html:",
+      indexUrl,
+      err,
+    );
+  }
+};
+
+const toSharedFactory = (mod) => {
+  const exportModule = { ...mod };
+  if (!("default" in exportModule)) {
+    exportModule.default = mod;
+  }
+  Object.defineProperty(exportModule, "__esModule", {
+    value: true,
+    enumerable: false,
+  });
+  return async () => () => exportModule;
+};
+
+const resolveVersion = (mod, fallback = false) => mod?.version || fallback;
+
+const buildHostShareScope = () => ({
+  react: {
+    [resolveVersion(React, "19.0.0")]: {
+      name: "react",
+      version: resolveVersion(React, "19.0.0"),
+      scope: ["default"],
+      from: "host-manual-loader",
+      loaded: true,
+      shareConfig: { singleton: true, requiredVersion: false },
+      get: toSharedFactory(React),
+    },
+  },
+  "react-dom": {
+    [resolveVersion(ReactDom, "19.0.0")]: {
+      name: "react-dom",
+      version: resolveVersion(ReactDom, "19.0.0"),
+      scope: ["default"],
+      from: "host-manual-loader",
+      loaded: true,
+      shareConfig: { singleton: true, requiredVersion: false },
+      get: toSharedFactory(ReactDom),
+    },
+  },
+  "react/jsx-runtime": {
+    [resolveVersion(ReactJsxRuntime, "19.0.0")]: {
+      name: "react/jsx-runtime",
+      version: resolveVersion(ReactJsxRuntime, "19.0.0"),
+      scope: ["default"],
+      from: "host-manual-loader",
+      loaded: true,
+      shareConfig: { singleton: true, requiredVersion: false },
+      get: toSharedFactory(ReactJsxRuntime),
+    },
+  },
+  tslib: {
+    [resolveVersion(tslibModule, "2.8.1")]: {
+      name: "tslib",
+      version: resolveVersion(tslibModule, "2.8.1"),
+      scope: ["default"],
+      from: "host-manual-loader",
+      loaded: true,
+      shareConfig: { singleton: true, requiredVersion: false },
+      get: toSharedFactory(tslibModule),
+    },
+  },
+});
+
+export const loadFederatedComponent = async ({
+  id,
+  remoteUrl,
+  exposedModule = "./PluginApp",
+}) => {
+  if (federationCache.has(id)) return federationCache.get(id);
+
+  const resolvedUrl = resolveRemoteUrl(remoteUrl);
+
+  try {
+    initializeDevContext();
+
+    await injectStylesheetsFromRemoteIndexHtml(resolvedUrl);
+
+    const container = await import(/* @vite-ignore */ resolvedUrl);
+
+    // Pass a simple share scope — the plugin declares react as shared/singleton
+    // so the federation runtime will use the host's already-loaded React
+    // rather than loading a second copy.
+    if (container.init) {
+      await container.init(buildHostShareScope());
+    }
+
+    const candidates = buildExposeCandidates(exposedModule);
+    let factory = null;
+    let lastError = null;
+    for (const candidate of candidates) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        factory = await container.get(candidate);
+        if (factory) break;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    if (!factory) {
+      const requested = normalizeExposedModule(exposedModule);
+      throw new Error(
+        `[Federation] Module "${requested}" not found in remote "${id}". Tried: ${candidates.join(", ")}`,
+        { cause: lastError || undefined },
+      );
+    }
+
+    const mod = factory();
+    const component = mod.default ?? mod;
+
+    federationCache.set(id, component);
+    return component;
+  } catch (err) {
+    console.error("[Federation] load failed:", id, err);
+    throw err;
+  }
+};
+
+// ─────────────────────────────────────────────
+// Eviction
+// ─────────────────────────────────────────────
+
+export const fullEvictPlugin = async (id) => {
+  federationCache.delete(id);
+  registeredRemotes.delete(id);
+};
+
+export const evictFederatedPlugin = ({ id }) => {
+  federationCache.delete(id);
+  registeredRemotes.delete(id);
+};
+
+// ─────────────────────────────────────────────
+// Federation discovery
+// ─────────────────────────────────────────────
+
+export const discoverFederatedPlugins = async () => {
+  const res = await fetch(`${API_URL}/plugins`);
+  const body = await res.json();
+  const plugins = Array.isArray(body) ? body : [];
+
+  const pages = {};
+
+  for (const plugin of plugins) {
+    if (plugin.enabled === false) continue;
+
+    const { id, name, remoteUrl, fe_exposed_module, icon } = plugin;
+
+    const exposedModule = normalizeExposedModule(fe_exposed_module);
+
+    const PluginPage = React.lazy(() =>
+      loadFederatedComponent({ id, remoteUrl, exposedModule }).then((comp) => ({
+        default: comp,
+      })),
+    );
+
+    pages[id] = {
+      component: PluginPage,
+      path: id,
+      name: name || formatPluginName(id),
+      icon: icon || null,
+      _source: "federation",
+      _raw: plugin,
+    };
+  }
+
+  return pages;
+};
+
+// ─────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────
+
+export const initializePluginOrder = () => fetchPluginOrder();
+
 export const getPluginPages = () => {
   const pages = discoverPluginPages();
   const order = cachedPluginOrder || [];
-  const sortedPlugins = sortPluginsByOrder(pages, order);
-
-  if (cachedPluginOrder === null && !orderFetchPromise) {
-    fetchPluginOrder();
-  }
-
-  const sortedPages = {};
-  for (const { key, plugin } of sortedPlugins) {
-    sortedPages[key] = plugin;
-  }
-
-  return sortedPages;
+  const sorted = sortPluginsByOrder(pages, order);
+  const result = {};
+  for (const { key, plugin } of sorted) result[key] = plugin;
+  if (cachedPluginOrder === null && !orderFetchPromise) fetchPluginOrder();
+  return result;
 };
 
-// Get plugin pages filtered by feature config (async)
-export const getPluginPagesFiltered = async () => {
-  const pages = discoverPluginPages();
-  const order = cachedPluginOrder || [];
-  const sortedPlugins = sortPluginsByOrder(pages, order);
+export const refreshPluginPages = async () => {
+  const order = await fetchPluginOrder();
 
-  if (cachedPluginOrder === null && !orderFetchPromise) {
-    fetchPluginOrder();
-  }
+  let local = {};
+  let federated = {};
 
-  const filteredPlugins = [];
-  for (const { key, plugin } of sortedPlugins) {
-    if (await isPluginEnabled(key)) {
-      filteredPlugins.push({ key, plugin });
-    }
-  }
+  try {
+    local = discoverPluginPages();
+  } catch {}
+  try {
+    federated = await discoverFederatedPlugins();
+  } catch {}
 
-  const filteredPages = {};
-  for (const { key, plugin } of filteredPlugins) {
-    filteredPages[key] = plugin;
-  }
+  const merged = { ...local, ...federated };
+  const sorted = sortPluginsByOrder(merged, order);
 
-  return filteredPages;
+  const result = {};
+  for (const { key, plugin } of sorted) result[key] = plugin;
+  return result;
 };
 
-// Get plugin sidebar items (sorted by plugin order)
-export const getPluginSidebarItems = () => {
-  const pages = discoverPluginPages();
+export const getPluginSidebarItems = (pages) => {
+  const resolved = pages ?? getPluginPages();
   const order = cachedPluginOrder || [];
-  const sortedPlugins = sortPluginsByOrder(pages, order);
-
-  if (cachedPluginOrder === null && !orderFetchPromise) {
-    fetchPluginOrder();
-  }
-
-  return sortedPlugins.map(({ plugin }) => ({
+  const sorted = sortPluginsByOrder(resolved, order);
+  return sorted.map(({ plugin }) => ({
     path: plugin.path,
     name: plugin.name,
-    icon: plugin.icon
+    icon: plugin.icon,
   }));
-};
-
-// Get plugin sidebar items filtered by feature config (async)
-export const getPluginSidebarItemsFiltered = async () => {
-  const pages = discoverPluginPages();
-  const order = cachedPluginOrder || [];
-  const sortedPlugins = sortPluginsByOrder(pages, order);
-
-  if (cachedPluginOrder === null && !orderFetchPromise) {
-    fetchPluginOrder();
-  }
-
-  const filteredItems = [];
-  for (const { plugin } of sortedPlugins) {
-    if (await isPluginEnabled(plugin.path)) {
-      filteredItems.push({
-        path: plugin.path,
-        name: plugin.name,
-        icon: plugin.icon
-      });
-    }
-  }
-
-  return filteredItems;
-};
-
-// Initialize plugin order fetch (call this early to preload the order)
-export const initializePluginOrder = () => {
-  const result = fetchPluginOrder();
-  return Promise.resolve(result);
 };

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/MarketplacePage.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/MarketplacePage.js
@@ -1,0 +1,534 @@
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import "./styles/MarketplacePage.css";
+import { Box, Modal } from "@mui/material";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import Button from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import PluginDetailsView from "./PluginDetails";
+import {
+  getInstalledPlugins,
+  enablePlugin,
+  disablePlugin,
+  uninstallPlugin,
+} from "./marketplace_api";
+import {
+  compareVersions,
+  mergeLatestRegistryPluginsBySlug,
+  versionToString,
+} from "./utils/versionUtils";
+import { installedRecordToDisplayPlugin } from "./utils/installedDisplay";
+import useRegistry from "./hooks/useRegistry";
+import useDownloadManager from "./hooks/useDownloadManager";
+import usePluginInstall from "./hooks/usePluginInstall";
+import { fullEvictPlugin } from "../loader";
+import PluginCard from "./components/PluginCard";
+import ZipInstall from "./components/ZipInstall";
+import PluginStats from "./components/PluginStats";
+import RegistryEditor from "./components/RegistryEditor";
+import DownloadManager from "./components/DownloadManager";
+
+export const pluginMetadata = {
+  name: "Marketplace",
+  icon: null,
+};
+
+const API_URL = window._env_?.VITE_API_URL || "http://localhost:8080";
+
+const TABS = ["ALL", "INSTALLED"];
+
+const MODAL_STYLE = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "95vw",
+  height: "95vh",
+  maxWidth: "95vw",
+  bgcolor: "background.paper",
+  boxShadow: 24,
+  borderRadius: "20px",
+  outline: "none",
+  overflow: "auto",
+};
+
+const BACKDROP_PROPS = {
+  backdrop: {
+    style: {
+      backdropFilter: "blur(4px)",
+      backgroundColor: "rgba(0,0,0,0.4)",
+    },
+  },
+};
+
+const MarketplacePage = () => {
+  const [installedPlugins, setInstalledPlugins] = useState([]);
+  const [enabledSlugs, setEnabledSlugs] = useState(new Set());
+  const [selectedPlugin, setSelectedPlugin] = useState(null);
+  const [modalType, setModalType] = useState(null);
+  const [search, setSearch] = useState("");
+  const [activeTab, setActiveTab] = useState("ALL");
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [installMethod, setInstallMethod] = useState(null);
+  const [registries, setRegistries] = useState([]);
+
+  const {
+    fetchPlugins,
+    resetSources,
+    plugins: registryPluginsByUrl,
+  } = useRegistry();
+  const { installs, addInstall, updateInstall, removeInstall } =
+    useDownloadManager();
+  const { install } = usePluginInstall();
+
+  const fetchInstalled = useCallback(async () => {
+    try {
+      const installed = await getInstalledPlugins();
+      setInstalledPlugins(installed);
+      setEnabledSlugs(
+        new Set(
+          installed.filter((p) => p.enabled !== false).map((p) => p.slug),
+        ),
+      );
+    } catch (e) {
+      console.error("Failed getting installed plugins:", e);
+    }
+  }, []);
+
+  /** Refetch marketplace state and notify Sidebar + Dashboard. */
+  const refreshInstalledAndBroadcast = useCallback(async () => {
+    await fetchInstalled();
+    window.dispatchEvent(new CustomEvent("anylog:plugins-changed"));
+  }, [fetchInstalled]);
+
+  useEffect(() => {
+    fetchInstalled();
+  }, [fetchInstalled]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(
+        "plugin-marketplace/registries/sources",
+      );
+      if (stored) {
+        setRegistries(JSON.parse(stored));
+      } else {
+        const defaults = [
+          {
+            url: "http://localhost:8081/registry-manifest.json",
+            enabled: true,
+          },
+        ];
+        localStorage.setItem(
+          "plugin-marketplace/registries/sources",
+          JSON.stringify(defaults),
+        );
+        setRegistries(defaults);
+      }
+    } catch (e) {
+      console.error(
+        "[plugin-marketplace] failed retrieving registry sources:",
+        e,
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    const enabled = registries.filter((r) => r.enabled);
+    const urls = enabled.map((r) => r.url);
+    resetSources(urls);
+    enabled.forEach((r) =>
+      fetchPlugins(r.url).catch(() =>
+        console.error("Failed loading registry:", r),
+      ),
+    );
+  }, [registries, resetSources, fetchPlugins]);
+
+  const latestRegistryPluginBySlug = useMemo(
+    () => mergeLatestRegistryPluginsBySlug(registryPluginsByUrl),
+    [registryPluginsByUrl],
+  );
+
+  /** Installed slug → { registryPlugin, installedVersion, latestVersion } when registry is newer */
+  const pendingUpdatesBySlug = useMemo(() => {
+    const out = {};
+    for (const inst of installedPlugins) {
+      const latest = latestRegistryPluginBySlug.get(inst.slug);
+      if (!latest) continue;
+      const cmp = compareVersions(latest.core.version, inst.version);
+      if (cmp > 0) {
+        out[inst.slug] = {
+          registryPlugin: latest,
+          installedVersion: versionToString(inst.version),
+          latestVersion: versionToString(latest.core.version),
+        };
+      }
+    }
+    return out;
+  }, [installedPlugins, latestRegistryPluginBySlug]);
+
+  const handleInstall = (plugin) => {
+    addInstall(plugin.core.slug, plugin.core.name);
+    install(plugin, {
+      onStatusChange: updateInstall,
+      onInstallComplete: refreshInstalledAndBroadcast,
+    });
+  };
+
+  const handleEnabledStateChange = async (slug, currentlyEnabled) => {
+    try {
+      const row = installedPlugins.find((p) => p.slug === slug);
+      if (currentlyEnabled) {
+        await disablePlugin(slug);
+        setEnabledSlugs((prev) => {
+          const n = new Set(prev);
+          n.delete(slug);
+          return n;
+        });
+      } else {
+        await enablePlugin(slug);
+        setEnabledSlugs((prev) => new Set(prev).add(slug));
+      }
+      if (row?.id) await fullEvictPlugin(row.id);
+      window.dispatchEvent(new CustomEvent("anylog:plugins-changed"));
+      await fetchInstalled();
+    } catch (e) {
+      console.error("Failed toggling plugin state:", e);
+    }
+  };
+
+  const handleUninstall = async (slug) => {
+    try {
+      await uninstallPlugin(slug);
+      await refreshInstalledAndBroadcast();
+    } catch (e) {
+      console.error("Failed uninstalling plugin:", e);
+    }
+  };
+
+  const handleUpdate = async (registryPlugin) => {
+    const slug = registryPlugin.core.slug;
+    const row = installedPlugins.find((p) => p.slug === slug);
+    const wasEnabled = enabledSlugs.has(slug);
+
+    addInstall(slug, `${registryPlugin.core.name} (update)`);
+    updateInstall(slug, { status: "installing", progress: [], error: null });
+    updateInstall(slug, { progress_step: "Removing previous version" });
+
+    try {
+      await uninstallPlugin(slug);
+      if (row?.id) await fullEvictPlugin(row.id);
+      window.dispatchEvent(new CustomEvent("anylog:plugins-changed"));
+      await fetchInstalled();
+    } catch (e) {
+      updateInstall(slug, {
+        status: "failed",
+        error: e.message || String(e),
+      });
+      return;
+    }
+
+    updateInstall(slug, { progress_step: "Installing new version" });
+    install(registryPlugin, {
+      onStatusChange: updateInstall,
+      onInstallComplete: async () => {
+        if (!wasEnabled) {
+          try {
+            await disablePlugin(slug);
+          } catch (err) {
+            console.warn("Post-update disable failed:", err);
+          }
+        }
+        await refreshInstalledAndBroadcast();
+      },
+    });
+  };
+
+  const handleRegistrySave = () => {
+    try {
+      const stored = localStorage.getItem(
+        "plugin-marketplace/registries/sources",
+      );
+      if (stored) setRegistries(JSON.parse(stored));
+    } catch (e) {
+      console.error("Failed reloading registries:", e);
+    }
+    fetchInstalled();
+  };
+
+  const marketplaceRows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const matchesSearch = (p) => {
+      if (!p?.core) return false;
+      if (!q) return true;
+      const name = String(p.core.name || "").toLowerCase();
+      const slug = String(p.core.slug || "").toLowerCase();
+      const desc = String(p.core.description || "").toLowerCase();
+      return name.includes(q) || slug.includes(q) || desc.includes(q);
+    };
+
+    const flat = Object.values(registryPluginsByUrl).flat();
+
+    if (activeTab === "ALL") {
+      return flat.filter(matchesSearch).map((p) => ({
+        key: p.core.id || p.core.slug,
+        slug: p.core.slug,
+        plugin: p,
+      }));
+    }
+
+    return installedPlugins
+      .map((inst) => {
+        const fromRegistry = latestRegistryPluginBySlug.get(inst.slug);
+        const plugin = fromRegistry ?? installedRecordToDisplayPlugin(inst);
+        if (!plugin) return null;
+        return {
+          key: `installed-${inst.slug}`,
+          slug: inst.slug,
+          plugin,
+        };
+      })
+      .filter(Boolean)
+      .filter((row) => matchesSearch(row.plugin));
+  }, [
+    activeTab,
+    search,
+    installedPlugins,
+    registryPluginsByUrl,
+    latestRegistryPluginBySlug,
+  ]);
+
+  const detailSlug = selectedPlugin?.core?.slug;
+  const detailInstalled =
+    detailSlug != null
+      ? installedPlugins.find((i) => i.slug === detailSlug)
+      : undefined;
+  const detailPending =
+    detailSlug != null ? pendingUpdatesBySlug[detailSlug] : undefined;
+  const detailInstallEntry =
+    detailSlug != null ? installs.find((i) => i.slug === detailSlug) : undefined;
+  const detailInstallBusy = Boolean(
+    detailInstallEntry &&
+      (detailInstallEntry.status === "installing" ||
+        detailInstallEntry.status === "enabling"),
+  );
+  const detailProgressTail =
+    detailInstallEntry?.progress?.length > 0
+      ? detailInstallEntry.progress[detailInstallEntry.progress.length - 1]
+      : "";
+  const detailInstallStatusText =
+    detailInstallEntry?.status === "enabling"
+      ? detailProgressTail || "Enabling plugin…"
+      : detailProgressTail || "Installing…";
+  const detailCardBusy =
+    detailSlug != null &&
+    installs.some(
+      (i) =>
+        i.slug === detailSlug &&
+        (i.status === "installing" || i.status === "enabling"),
+    );
+
+  return (
+    <div className="mp-page">
+      <header className="mp-header">
+        <div className="mp-header-text">
+          <h1>Plugin Marketplace</h1>
+          <p>Extend your workspace with official modules.</p>
+        </div>
+
+        <div className="mp-controls">
+          <div className="mp-tab-group">
+            {TABS.map((tab) => (
+              <button
+                key={tab}
+                className={`mp-tab ${activeTab === tab ? "mp-tab--active" : ""}`}
+                onClick={() => setActiveTab(tab)}
+              >
+                {tab}
+                {tab === "INSTALLED" && installedPlugins.length > 0 && (
+                  <span className="mp-tab-count">
+                    {installedPlugins.length}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+
+          <input
+            type="text"
+            className="mp-search"
+            placeholder="Search plugins…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+
+          <Button
+            variant="outlined"
+            endIcon={<KeyboardArrowDownIcon />}
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+            className="mp-install-btn"
+          >
+            Install
+          </Button>
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={() => setAnchorEl(null)}
+            PaperProps={{ style: { borderRadius: "12px", marginTop: "6px" } }}
+          >
+            <MenuItem
+              onClick={() => {
+                setInstallMethod("MANIFEST");
+                setAnchorEl(null);
+              }}
+            >
+              Direct Manifest
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                setInstallMethod("REGISTRY");
+                setAnchorEl(null);
+              }}
+            >
+              Add a registry source
+            </MenuItem>
+          </Menu>
+        </div>
+      </header>
+
+      <DownloadManager installs={installs} onRemove={removeInstall} />
+
+      {marketplaceRows.length === 0 ? (
+        <p className="mp-empty">
+          {activeTab === "INSTALLED"
+            ? "No plugins installed yet."
+            : "No plugins found."}
+        </p>
+      ) : (
+        <div className="mp-grid">
+          {marketplaceRows.map((row) => {
+            const p = row.plugin;
+            const slug = row.slug;
+            const pending = pendingUpdatesBySlug[slug];
+            const busy = installs.some(
+              (i) =>
+                i.slug === slug &&
+                (i.status === "installing" || i.status === "enabling"),
+            );
+            const installedRow = installedPlugins.find((i) => i.slug === slug);
+            return (
+              <PluginCard
+                key={row.key}
+                plugin={p}
+                installed={installedRow}
+                enabled={enabledSlugs.has(slug)}
+                onInstall={() => handleInstall(p)}
+                onEnabledStateChange={(currentlyEnabled) =>
+                  handleEnabledStateChange(slug, currentlyEnabled)
+                }
+                onUninstall={() => handleUninstall(slug)}
+                onExpand={() => {
+                  setModalType("details");
+                  setSelectedPlugin(p);
+                }}
+                onTriggerMetrics={() => {
+                  setModalType("stats");
+                  setSelectedPlugin(p);
+                }}
+                updateInfo={
+                  pending
+                    ? {
+                        installedVersion: pending.installedVersion,
+                        latestVersion: pending.latestVersion,
+                      }
+                    : null
+                }
+                onUpdate={
+                  pending
+                    ? () => handleUpdate(pending.registryPlugin)
+                    : undefined
+                }
+                updateInProgress={Boolean(pending && busy)}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {installMethod === "MANIFEST" && (
+        <Modal
+          open
+          onClose={() => setInstallMethod(null)}
+          slotProps={BACKDROP_PROPS}
+        >
+          <Box sx={MODAL_STYLE}>
+            <ZipInstall onInstallComplete={refreshInstalledAndBroadcast} />
+          </Box>
+        </Modal>
+      )}
+
+      {installMethod === "REGISTRY" && (
+        <Modal
+          open
+          onClose={() => setInstallMethod(null)}
+          slotProps={BACKDROP_PROPS}
+        >
+          <Box sx={MODAL_STYLE}>
+            <RegistryEditor onSave={handleRegistrySave} />
+          </Box>
+        </Modal>
+      )}
+
+      {selectedPlugin && (
+        <Modal
+          open
+          onClose={() => setSelectedPlugin(null)}
+          slotProps={BACKDROP_PROPS}
+        >
+          <Box sx={MODAL_STYLE}>
+            {modalType === "stats" ? (
+              <PluginStats
+                sseUrl={`${API_URL}/plugins/logs?slug=${encodeURIComponent(selectedPlugin.core.slug)}`}
+              />
+            ) : (
+              <PluginDetailsView
+                selectedPlugin={selectedPlugin}
+                closeModalCallback={() => setSelectedPlugin(null)}
+                installed={detailInstalled}
+                enabled={detailSlug != null && enabledSlugs.has(detailSlug)}
+                onInstall={() => handleInstall(selectedPlugin)}
+                onEnabledStateChange={(currentlyEnabled) => {
+                  if (detailSlug != null) {
+                    void handleEnabledStateChange(detailSlug, currentlyEnabled);
+                  }
+                }}
+                onUninstall={() => {
+                  if (detailSlug != null) void handleUninstall(detailSlug);
+                }}
+                onTriggerMetrics={() => setModalType("stats")}
+                updateInfo={
+                  detailPending
+                    ? {
+                        installedVersion: detailPending.installedVersion,
+                        latestVersion: detailPending.latestVersion,
+                      }
+                    : null
+                }
+                onUpdate={
+                  detailPending
+                    ? () => handleUpdate(detailPending.registryPlugin)
+                    : undefined
+                }
+                updateInProgress={Boolean(detailPending && detailCardBusy)}
+                installBusy={detailInstallBusy}
+                installStatusText={detailInstallStatusText}
+              />
+            )}
+          </Box>
+        </Modal>
+      )}
+    </div>
+  );
+};
+
+export default MarketplacePage;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/PluginDetails.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/PluginDetails.js
@@ -1,0 +1,497 @@
+import React, { useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Divider from "@mui/material/Divider";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import { FaCircle } from "react-icons/fa";
+
+const PluginDetailsView = ({
+  selectedPlugin,
+  closeModalCallback,
+  installed = null,
+  enabled = false,
+  onInstall,
+  onEnabledStateChange,
+  onUninstall,
+  onTriggerMetrics,
+  updateInfo = null,
+  onUpdate,
+  updateInProgress = false,
+  installBusy = false,
+  installStatusText = "",
+}) => {
+  const [readmeContent, setReadmeContent] = useState(null);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const menuOpen = Boolean(anchorEl);
+
+  const handleMenuOpen = (e) => {
+    e.stopPropagation();
+    setAnchorEl(e.currentTarget);
+  };
+  const handleMenuClose = () => setAnchorEl(null);
+
+  useEffect(() => {
+    if (!selectedPlugin?.readme_link) return;
+
+    setReadmeContent(null);
+
+    fetch(selectedPlugin.readme_link)
+      .then((res) => res.text())
+      .then(setReadmeContent)
+      .catch((e) => {
+        console.error(
+          `Failed fetching readme from ${selectedPlugin.readme_link}`,
+          e,
+        );
+      });
+  }, [selectedPlugin.readme_link]);
+
+  return (
+    <div
+      style={{
+        padding: "32px",
+        backgroundColor: "white",
+        position: "relative",
+        height: "100%",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <button
+        onClick={closeModalCallback}
+        style={{
+          position: "absolute",
+          top: "16px",
+          right: "16px",
+          background: "#fee2e2",
+          border: "none",
+          borderRadius: "50%",
+          width: "32px",
+          height: "32px",
+          color: "#dc2626",
+          fontWeight: "700",
+          fontSize: "14px",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          zIndex: 10,
+        }}
+      >
+        ✕
+      </button>
+
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          scrollbarWidth: "none",
+          msOverflowStyle: "none",
+          paddingRight: "4px",
+        }}
+      >
+        <style>{`::-webkit-scrollbar { display: none; }`}</style>
+
+        <div style={{ display: "flex", gap: "40px" }}>
+          <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+            <div
+              style={{
+                display: "flex",
+                gap: "20px",
+                alignItems: "center",
+                marginBottom: "24px",
+              }}
+            >
+              {selectedPlugin.thumbnail ? (
+                <img
+                  src={selectedPlugin.thumbnail}
+                  style={{
+                    width: "90px",
+                    height: "90px",
+                    borderRadius: "20px",
+                    objectFit: "cover",
+                    boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+                  }}
+                  alt=""
+                />
+              ) : (
+                <div
+                  style={{
+                    width: "90px",
+                    height: "90px",
+                    borderRadius: "20px",
+                    background: "#e5e7eb",
+                    color: "#6b7280",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontWeight: "700",
+                    fontSize: "14px",
+                  }}
+                  aria-hidden
+                >
+                  Plugin
+                </div>
+              )}
+              <div>
+                <h2
+                  style={{
+                    margin: "0 0 4px",
+                    fontSize: "24px",
+                    fontWeight: "800",
+                    color: "#111827",
+                  }}
+                >
+                  {selectedPlugin.core.name}
+                </h2>
+                <span
+                  style={{
+                    fontSize: "13px",
+                    color: "#6b7280",
+                    fontWeight: "500",
+                  }}
+                >
+                  {selectedPlugin.core.slug}
+                </span>
+              </div>
+            </div>
+
+            <div style={{ display: "flex", gap: "24px", marginBottom: "28px" }}>
+              <div
+                style={{
+                  backgroundColor: "#f9fafb",
+                  borderRadius: "14px",
+                  padding: "14px 20px",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "4px",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "12px",
+                    color: "#9ca3af",
+                    fontWeight: "500",
+                  }}
+                >
+                  VERSION
+                </span>
+                <span
+                  style={{
+                    fontSize: "15px",
+                    fontWeight: "700",
+                    color: "#111827",
+                  }}
+                >
+                  v{selectedPlugin.core.version}
+                </span>
+              </div>
+              {selectedPlugin.downloadCount && (
+                <div
+                  style={{
+                    backgroundColor: "#f9fafb",
+                    borderRadius: "14px",
+                    padding: "14px 20px",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "4px",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "12px",
+                      color: "#9ca3af",
+                      fontWeight: "500",
+                    }}
+                  >
+                    DOWNLOADS
+                  </span>
+                  <span
+                    style={{
+                      fontSize: "15px",
+                      fontWeight: "700",
+                      color: "#111827",
+                    }}
+                  >
+                    {selectedPlugin.downloadCount.toLocaleString()}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <p
+              style={{
+                color: "#6b7280",
+                lineHeight: 1.7,
+                fontSize: "15px",
+                margin: 0,
+              }}
+            >
+              {selectedPlugin.core.description}
+            </p>
+          </div>
+
+          <div
+            style={{
+              width: "200px",
+              flexShrink: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+              paddingTop: "4px",
+            }}
+          >
+            <p
+              style={{
+                margin: "0 0 8px",
+                fontSize: "12px",
+                fontWeight: "700",
+                color: "#9ca3af",
+                letterSpacing: "0.05em",
+              }}
+            >
+              LINKS
+            </p>
+            {[
+              {
+                label: "📦 Repository",
+                href: selectedPlugin.repository_link || "#",
+              },
+              { label: "🐛 Report a Bug", href: selectedPlugin.bugLink || "#" },
+            ].map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: "block",
+                  padding: "10px 14px",
+                  borderRadius: "12px",
+                  backgroundColor: "#f9fafb",
+                  color: "#374151",
+                  fontSize: "13px",
+                  fontWeight: "500",
+                  textDecoration: "none",
+                  border: "1px solid #f3f4f6",
+                }}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {readmeContent && (
+          <>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "12px",
+                margin: "32px 0 24px",
+              }}
+            >
+              <div
+                style={{ flex: 1, height: "1px", backgroundColor: "#e5e7eb" }}
+              />
+              <span
+                style={{
+                  fontSize: "11px",
+                  fontWeight: "700",
+                  color: "#9ca3af",
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                }}
+              >
+                README
+              </span>
+              <div
+                style={{ flex: 1, height: "1px", backgroundColor: "#e5e7eb" }}
+              />
+            </div>
+
+            <div
+              className="markdown-body"
+              style={{ fontSize: "14px", color: "#374151", lineHeight: 1.7 }}
+            >
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {readmeContent}
+              </ReactMarkdown>
+            </div>
+          </>
+        )}
+      </div>
+
+      <div
+        style={{
+          paddingTop: "16px",
+          borderTop: "1px solid #f3f4f6",
+          marginTop: "8px",
+          flexShrink: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+        }}
+      >
+        {!installed ? (
+          <button
+            type="button"
+            onClick={() => onInstall?.()}
+            disabled={installBusy || !onInstall}
+            style={{
+              width: "100%",
+              padding: "14px",
+              border: "none",
+              backgroundColor: installBusy ? "#93c5fd" : "#3b82f6",
+              color: "white",
+              borderRadius: "14px",
+              fontWeight: "700",
+              fontSize: "15px",
+              cursor:
+                installBusy || !onInstall ? "not-allowed" : "pointer",
+              letterSpacing: "-0.2px",
+              transition: "background-color 0.2s",
+            }}
+          >
+            {installBusy
+              ? installStatusText || "Installing…"
+              : "Install plugin"}
+          </button>
+        ) : (
+          <>
+            {updateInfo && onUpdate && (
+              <div className="mp-plugin-update-row">
+                <div className="mp-plugin-update-meta">
+                  Update available: installed v{updateInfo.installedVersion} →
+                  registry v{updateInfo.latestVersion}
+                </div>
+                <button
+                  type="button"
+                  className="mp-plugin-update-btn"
+                  disabled={updateInProgress}
+                  onClick={() => onUpdate()}
+                >
+                  {updateInProgress
+                    ? "Updating…"
+                    : `Update to v${updateInfo.latestVersion}`}
+                </button>
+              </div>
+            )}
+            <div
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                borderRadius: "999px",
+                border: "1px solid #e5e7eb",
+                backgroundColor: "#f9fafb",
+                overflow: "hidden",
+                width: "100%",
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => onTriggerMetrics?.()}
+                style={{
+                  flex: 1,
+                  padding: "12px 16px",
+                  border: "none",
+                  background: "transparent",
+                  fontWeight: "600",
+                  fontSize: "14px",
+                  color: "#111827",
+                  cursor: onTriggerMetrics ? "pointer" : "default",
+                  textAlign: "left",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                View logs and metrics
+              </button>
+              <div
+                style={{
+                  width: "1px",
+                  height: "22px",
+                  backgroundColor: "#e5e7eb",
+                  flexShrink: 0,
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleMenuOpen}
+                style={{
+                  padding: "12px 14px",
+                  border: "none",
+                  background: "transparent",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  color: "#6b7280",
+                }}
+              >
+                <ArrowDropDownIcon />
+              </button>
+            </div>
+
+            <Menu
+              anchorEl={anchorEl}
+              open={menuOpen}
+              onClose={handleMenuClose}
+              transformOrigin={{ horizontal: "right", vertical: "top" }}
+              anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+              slotProps={{
+                paper: {
+                  style: {
+                    borderRadius: "14px",
+                    boxShadow: "0 8px 24px rgba(0,0,0,0.10)",
+                    padding: "4px",
+                    marginTop: "4px",
+                  },
+                },
+              }}
+            >
+              <MenuItem
+                onClick={() => {
+                  onEnabledStateChange?.(enabled);
+                  handleMenuClose();
+                }}
+                style={{
+                  borderRadius: "10px",
+                  fontSize: "13px",
+                  fontWeight: "600",
+                }}
+              >
+                <span style={{ marginRight: "10px" }}>
+                  <FaCircle color={enabled ? "red" : "green"} />
+                </span>
+                {enabled ? "Disable" : "Enable"}
+              </MenuItem>
+
+              <Divider style={{ margin: "4px 0" }} />
+
+              <MenuItem
+                onClick={() => {
+                  onUninstall?.();
+                  handleMenuClose();
+                }}
+                style={{
+                  borderRadius: "10px",
+                  fontSize: "13px",
+                  fontWeight: "600",
+                  color: "#dc2626",
+                }}
+              >
+                <span style={{ marginRight: "10px" }}>🗑️</span>
+                Uninstall
+              </MenuItem>
+            </Menu>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PluginDetailsView;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/PluginErrorBoundary.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/PluginErrorBoundary.js
@@ -1,0 +1,133 @@
+import React from "react";
+import { fullEvictPlugin } from "../loader";
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 500;
+
+class PluginErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      retryCount: 0,
+      mountKey: 0,
+    };
+    this._retryTimer = null;
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("[PluginErrorBoundary] Caught render error:", error, info);
+    const { retryCount } = this.state;
+
+    if (retryCount < MAX_RETRIES) {
+      const delay = RETRY_DELAY_MS * Math.pow(2, retryCount);
+      console.log(
+        `[PluginErrorBoundary] Retrying (${retryCount + 1}/${MAX_RETRIES}) in ${delay}ms...`,
+      );
+
+      this._retryTimer = setTimeout(async () => {
+        const { pluginId, componentName, remoteUrl } = this.props;
+        if (pluginId && componentName && remoteUrl) {
+          await fullEvictPlugin(pluginId, componentName, remoteUrl);
+        }
+        this.setState((prev) => ({
+          hasError: false,
+          error: null,
+          retryCount: prev.retryCount + 1,
+          mountKey: prev.mountKey + 1,
+        }));
+      }, delay);
+    }
+  }
+
+  handleManualReset = async () => {
+    clearTimeout(this._retryTimer);
+    const { pluginId, componentName, remoteUrl } = this.props;
+    if (pluginId && componentName && remoteUrl) {
+      await fullEvictPlugin(pluginId, componentName, remoteUrl);
+    }
+    this.setState({
+      hasError: false,
+      error: null,
+      retryCount: 0,
+      mountKey: this.state.mountKey + 1,
+    });
+  };
+
+  componentWillUnmount() {
+    clearTimeout(this._retryTimer);
+  }
+
+  render() {
+    const { hasError, error, retryCount, mountKey } = this.state;
+
+    if (hasError) {
+      const exhausted = retryCount >= MAX_RETRIES;
+      return (
+        <div
+          style={{
+            padding: "20px",
+            border: "1px solid #fca5a5",
+            backgroundColor: "#fef2f2",
+            borderRadius: "12px",
+            textAlign: "center",
+          }}
+        >
+          <h3 style={{ color: "#991b1b", margin: "0 0 8px 0" }}>
+            Plugin Load Error
+          </h3>
+          {!exhausted ? (
+            <p style={{ color: "#b91c1c", fontSize: "14px" }}>
+              Retrying... ({retryCount}/{MAX_RETRIES})
+            </p>
+          ) : (
+            <>
+              <p style={{ color: "#b91c1c", fontSize: "14px" }}>
+                This plugin failed to load after {MAX_RETRIES} attempts.
+              </p>
+              {error && (
+                <pre
+                  style={{
+                    fontSize: "11px",
+                    color: "#7f1d1d",
+                    marginTop: "8px",
+                    textAlign: "left",
+                    overflowX: "auto",
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  {error.message}
+                </pre>
+              )}
+              <button
+                onClick={this.handleManualReset}
+                style={{
+                  marginTop: "10px",
+                  padding: "8px 16px",
+                  backgroundColor: "#991b1b",
+                  color: "white",
+                  border: "none",
+                  borderRadius: "6px",
+                  cursor: "pointer",
+                }}
+              >
+                Try Again
+              </button>
+            </>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <React.Fragment key={mountKey}>{this.props.children}</React.Fragment>
+    );
+  }
+}
+
+export default PluginErrorBoundary;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/components/DownloadManager.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/components/DownloadManager.js
@@ -1,0 +1,150 @@
+import React, { useState } from "react";
+import InstallStatus, { Spinner } from "./InstallStatus";
+
+const statusColor = {
+  installing: "#2563eb",
+  enabling: "#7c3aed",
+  complete: "#16a34a",
+  failed: "#dc2626",
+  cancelled: "#9ca3af",
+};
+
+const DownloadManager = ({ installs, onRemove }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const activeCount = installs.filter(
+    (i) => i.status === "installing" || i.status === "enabling",
+  ).length;
+
+  if (installs.length === 0) return null;
+
+  return (
+    <div style={containerStyle}>
+      <button onClick={() => setExpanded((v) => !v)} style={headerStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          {activeCount > 0 && <Spinner color="#2563eb" />}
+          <span
+            style={{ fontWeight: "600", fontSize: "13px", color: "#111827" }}
+          >
+            Downloads
+          </span>
+          <span style={badgeStyle(activeCount > 0)}>
+            {activeCount > 0
+              ? `${activeCount} active`
+              : `${installs.length} total`}
+          </span>
+        </div>
+        <span style={{ fontSize: "11px", color: "#9ca3af" }}>
+          {expanded ? "▲" : "▼"}
+        </span>
+      </button>
+
+      {expanded && (
+        <div style={{ borderTop: "1px solid #f3f4f6" }}>
+          {installs.map((item) => (
+            <div key={item.slug} style={itemStyle}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: "8px" }}
+                >
+                  <span
+                    style={{
+                      width: "8px",
+                      height: "8px",
+                      borderRadius: "50%",
+                      backgroundColor: statusColor[item.status] ?? "#d1d5db",
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span
+                    style={{
+                      fontSize: "13px",
+                      fontWeight: "600",
+                      color: "#111827",
+                    }}
+                  >
+                    {item.name}
+                  </span>
+                  <span style={{ fontSize: "11px", color: "#9ca3af" }}>
+                    {item.slug}
+                  </span>
+                </div>
+                {(item.status === "complete" ||
+                  item.status === "failed" ||
+                  item.status === "cancelled") && (
+                  <button
+                    onClick={() => onRemove(item.slug)}
+                    style={dismissStyle}
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+              <InstallStatus
+                status={item.status}
+                error={item.error}
+                progress={item.progress}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const containerStyle = {
+  position: "fixed",
+  bottom: "24px",
+  right: "24px",
+  width: "380px",
+  backgroundColor: "#fff",
+  border: "1px solid #e5e7eb",
+  borderRadius: "16px",
+  boxShadow: "0 4px 24px rgba(0,0,0,0.10)",
+  zIndex: 1000,
+  overflow: "hidden",
+};
+
+const headerStyle = {
+  width: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "12px 16px",
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+};
+
+const badgeStyle = (active) => ({
+  fontSize: "11px",
+  fontWeight: "600",
+  padding: "2px 8px",
+  borderRadius: "99px",
+  backgroundColor: active ? "#eff6ff" : "#f3f4f6",
+  color: active ? "#2563eb" : "#6b7280",
+});
+
+const itemStyle = {
+  padding: "12px 16px",
+  borderBottom: "1px solid #f9fafb",
+};
+
+const dismissStyle = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  color: "#9ca3af",
+  fontSize: "13px",
+  padding: "2px 6px",
+  borderRadius: "6px",
+};
+
+export default DownloadManager;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/components/InstallStatus.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/components/InstallStatus.js
@@ -1,0 +1,115 @@
+import React from "react";
+
+const statusColor = {
+  installing: "#2563eb",
+  enabling: "#7c3aed",
+  complete: "#16a34a",
+  failed: "#dc2626",
+  cancelled: "#9ca3af",
+};
+
+const statusLabel = (status, error) =>
+  ({
+    installing: "Installing…",
+    enabling: "Enabling plugin…",
+    complete: "Installed and enabled",
+    failed: `Failed: ${error}`,
+    cancelled: "Cancelled",
+  })[status];
+
+const InstallStatus = ({ status, error, progress }) => {
+  if (!status) return null;
+
+  const color = statusColor[status];
+  const label = statusLabel(status, error);
+  const installing = status === "installing" || status === "enabling";
+
+  return (
+    <div
+      style={{
+        marginTop: "16px",
+        paddingTop: "14px",
+        borderTop: "1px solid #f3f4f6",
+      }}
+    >
+      <div
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "6px",
+          fontSize: "13px",
+          fontWeight: "600",
+          color,
+          marginBottom: progress.length > 0 ? "10px" : 0,
+        }}
+      >
+        {installing && <Spinner color={color} />}
+        {label}
+      </div>
+
+      {progress.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+          {progress.map((msg, i) => {
+            const isLast = i === progress.length - 1 && installing;
+            const isDone = status === "complete" || i < progress.length - 1;
+            return (
+              <div
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  fontSize: "13px",
+                  color: isLast ? "#111827" : "#6b7280",
+                  fontWeight: isLast ? "600" : "400",
+                }}
+              >
+                <span
+                  style={{
+                    width: "7px",
+                    height: "7px",
+                    borderRadius: "50%",
+                    flexShrink: 0,
+                    backgroundColor: isDone
+                      ? "#16a34a"
+                      : isLast
+                        ? color
+                        : "#d1d5db",
+                  }}
+                />
+                {msg}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const Spinner = ({ color = "#2563eb" }) => {
+  React.useEffect(() => {
+    if (!document.getElementById("zip-panel-spin")) {
+      const s = document.createElement("style");
+      s.id = "zip-panel-spin";
+      s.textContent = `@keyframes zip-spin { to { transform: rotate(360deg); } }`;
+      document.head.appendChild(s);
+    }
+  }, []);
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: "11px",
+        height: "11px",
+        border: `2px solid ${color}33`,
+        borderTopColor: color,
+        borderRadius: "50%",
+        animation: "zip-spin 0.7s linear infinite",
+        flexShrink: 0,
+      }}
+    />
+  );
+};
+
+export default InstallStatus;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/components/PluginCard.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/components/PluginCard.js
@@ -1,0 +1,132 @@
+import React, { useState } from "react";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Divider from "@mui/material/Divider";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import { FaCircle } from "react-icons/fa";
+
+const PluginCard = ({
+  plugin,
+  installed,
+  enabled,
+  onInstall,
+  onEnabledStateChange,
+  onUninstall,
+  onExpand,
+  onTriggerMetrics,
+  updateInfo = null,
+  onUpdate,
+  updateInProgress = false,
+}) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const menuOpen = Boolean(anchorEl);
+
+  const handleMenuOpen = (e) => { e.stopPropagation(); setAnchorEl(e.currentTarget); };
+  const handleMenuClose = () => setAnchorEl(null);
+
+  return (
+    <div style={{ backgroundColor: "#fff", borderRadius: "24px", padding: "20px", border: "1px solid #f3f4f6", boxShadow: "0 10px 15px -3px rgba(0,0,0,0.04)", display: "flex", flexDirection: "column", gap: "16px" }}>
+      <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+        <div style={{ position: "relative", width: "64px", height: "64px" }}>
+          {plugin.thumbnail && (
+            // <img src={plugin.thumbnail} style={{ width: "64px", height: "64px", borderRadius: "16px", objectFit: "cover" }} alt="" />
+            <img src={plugin.thumbnail}
+              style={{
+                width: "64px",
+                height: "64px",
+                borderRadius: "20px",
+                objectFit: "cover",
+                boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+              }}
+            />
+          )
+          }
+          {plugin.authorThumbnail && (
+            <img src={plugin.authorThumbnail} style={{ width: "18px", height: "18px", borderRadius: "50%", objectFit: "cover", position: "absolute", bottom: "-2px", right: "-2px", border: "2px solid white", boxShadow: "0 1px 3px rgba(0,0,0,0.3)" }} alt="" />
+          )}
+        </div>
+        <div style={{ flex: 1 }}>
+          <h3 style={{ margin: 0, fontSize: "17px", fontWeight: "700" }}>{plugin.core.name}</h3>
+          <div style={{ display: "flex", gap: 4 }}>
+            <span style={{ margin: 0, fontSize: "13px", fontWeight: "400" }}>{plugin.core.slug}</span>
+            <span style={{ fontSize: "12px", color: "#9ca3af" }}>v{plugin.core.version}</span>
+          </div>
+        </div>
+        <button onClick={onExpand} style={{ background: "none", border: "none", color: "#3b82f6", fontWeight: "600", cursor: "pointer", fontSize: "13px" }}>
+          Details
+        </button>
+      </div>
+
+      <p style={{ margin: 0, fontSize: "14px", color: "#6b7280", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden", minHeight: "40px" }}>
+        {plugin.core.description}
+      </p>
+
+      <div style={{ marginTop: "auto" }}>
+        {!installed ? (
+          <button onClick={onInstall} style={{ width: "100%", padding: "10px", borderRadius: "12px", border: "none", backgroundColor: "#3b82f6", color: "white", fontWeight: "600", cursor: "pointer", fontSize: "14px" }}>
+            Install
+          </button>
+        ) : (
+          <>
+            {updateInfo && onUpdate && (
+              <div className="mp-plugin-update-row">
+                <div className="mp-plugin-update-meta">
+                  Update available: installed v{updateInfo.installedVersion} → registry v
+                  {updateInfo.latestVersion}
+                </div>
+                <button
+                  type="button"
+                  className="mp-plugin-update-btn"
+                  disabled={updateInProgress}
+                  onClick={() => onUpdate()}
+                >
+                  {updateInProgress ? "Updating…" : `Update to v${updateInfo.latestVersion}`}
+                </button>
+              </div>
+            )}
+            <div style={{ display: "inline-flex", alignItems: "center", borderRadius: "999px", border: "1px solid #e5e7eb", backgroundColor: "#f9fafb", overflow: "hidden", width: "100%" }}>
+              <button onClick={onTriggerMetrics} style={{ flex: 1, padding: "10px 16px", border: "none", background: "transparent", fontWeight: "600", fontSize: "13px", color: "#111827", cursor: "pointer", textAlign: "left", whiteSpace: "nowrap" }}>
+                View logs and metrics
+              </button>
+              <div style={{ width: "1px", height: "20px", backgroundColor: "#e5e7eb", flexShrink: 0 }} />
+              <button onClick={handleMenuOpen} style={{ padding: "10px 14px", border: "none", background: "transparent", cursor: "pointer", display: "flex", alignItems: "center", color: "#6b7280" }}>
+                <ArrowDropDownIcon />
+              </button>
+            </div>
+
+            <Menu
+              anchorEl={anchorEl}
+              open={menuOpen}
+              onClose={handleMenuClose}
+              transformOrigin={{ horizontal: "right", vertical: "top" }}
+              anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+              slotProps={{ paper: { style: { borderRadius: "14px", boxShadow: "0 8px 24px rgba(0,0,0,0.10)", padding: "4px", marginTop: "4px" } } }}
+            >
+              <MenuItem
+                onClick={() => { onEnabledStateChange(enabled); handleMenuClose(); }}
+                style={{ borderRadius: "10px", fontSize: "13px", fontWeight: "600" }}
+              >
+                <span style={{ marginRight: "10px" }}>
+                  <FaCircle color={enabled ? "red" : "green"} />
+                </span>
+                {enabled ? "Disable" : "Enable"}
+              </MenuItem>
+
+              <Divider style={{ margin: "4px 0" }} />
+
+              <MenuItem
+                onClick={() => { onUninstall(); handleMenuClose(); }}
+                style={{ borderRadius: "10px", fontSize: "13px", fontWeight: "600", color: "#dc2626" }}
+              >
+                <span style={{ marginRight: "10px" }}>🗑️</span>
+                Uninstall
+              </MenuItem>
+            </Menu>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PluginCard;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/components/PluginStats.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/components/PluginStats.js
@@ -1,0 +1,351 @@
+import React, { useState, useEffect, useRef } from "react";
+import Chip from "@mui/material/Chip";
+import LinearProgress from "@mui/material/LinearProgress";
+
+const LEVELS = ["INFO", "WARN", "ERROR", "DEBUG", "RAW"];
+const CATEGORIES = ["UVICORN", "APP", "INSTALL", "RAW"];
+const LEVEL_COLORS = {
+  INFO: "info",
+  WARN: "warning",
+  ERROR: "error",
+  DEBUG: "secondary",
+  RAW: "default",
+};
+
+const PluginStats = ({ sseUrl }) => {
+  const [pluginMetrics, setPluginMetrics] = useState({});
+  const [logs, setLogs] = useState([]);
+  const [connStatus, setConnStatus] = useState("Waiting for events...");
+  const [filter, setFilter] = useState("ALL");
+  const [categoryFilter, setCategoryFilter] = useState("ALL");
+  const [paused, setPaused] = useState(false);
+  const [error, setError] = useState(null);
+  const pausedRef = useRef(false);
+  const logRef = useRef(null);
+  pausedRef.current = paused;
+
+  useEffect(() => {
+    if (!sseUrl) return;
+    const es = new EventSource(sseUrl);
+    es.onmessage = (e) => {
+      if (pausedRef.current) return;
+      try {
+        const data = JSON.parse(e.data);
+
+        if (data.event == "error") {
+          console.error("Plugin error", data.data);
+          setError(data.data);
+          es.close();
+          return;
+        } else {
+          setError(null);
+        }
+
+        setConnStatus("Waiting for log events to populate");
+
+        let metrics_data = {
+          cpu: 0,
+          memory_mb: 0,
+          memory_percent: 0,
+          rps: 0,
+        };
+
+        if (data.metrics?.cpu_percent) {
+          metrics_data.cpu = data.metrics.cpu_percent.toFixed(2);
+        }
+
+        if (data.metrics?.memory_mb) {
+          metrics_data.memory_mb = data.metrics.memory_mb.toFixed(2);
+        }
+
+        if (data.metrics?.memory_percent) {
+          metrics_data.memory_percent = data.metrics.memory_percent.toFixed(2);
+        }
+
+        setPluginMetrics(metrics_data);
+
+        if (data.log) {
+          const { level, category, message, context, raw } = data.log;
+          setLogs((l) =>
+            [
+              {
+                id: Date.now() + Math.random(),
+                ts: new Date().toLocaleTimeString(),
+                level,
+                category,
+                message,
+                context,
+                raw,
+              },
+              ...l,
+            ].slice(0, 200),
+          );
+        }
+      } catch {
+        setLogs((l) =>
+          [
+            {
+              id: Date.now(),
+              ts: new Date().toISOString(),
+              level: "INFO",
+              msg: e.data,
+            },
+            ...l,
+          ].slice(0, 200),
+        );
+      }
+    };
+    es.onerror = (e) => {
+      try {
+        console.log("ERORR EVENT SOURCE:");
+        console.log(e);
+        setConnStatus(e.detail);
+      } catch (e) {
+        setConnStatus("Unknown error connecting to log stream");
+      }
+    };
+    return () => es.close();
+  }, [sseUrl]);
+
+  useEffect(() => {
+    if (!paused && logRef.current) logRef.current.scrollTop = 0;
+  }, [logs, paused]);
+
+  // const filtered =
+  //   filter === "ALL" ? logs : logs.filter((l) => l.level === filter);
+  const filtered = logs.filter((l) => {
+    return true
+    if (filter !== "ALL" && l.level !== filter) return false;
+    if (categoryFilter !== "ALL" && l.category !== categoryFilter) return false;
+    return true;
+  });
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div
+        style={{
+          padding: "20px 24px",
+          borderBottom: "1px solid #e5e7eb",
+          background: "white",
+        }}
+      >
+        <p style={{ margin: "0 0 12px", fontSize: 13, fontWeight: 600 }}>
+          Metrics
+        </p>
+        <div style={{ display: "flex", gap: 24 }}>
+          {[
+            {
+              label: "CPU",
+              percentage_value: pluginMetrics.cpu,
+              unit: "%",
+              color:
+                pluginMetrics.cpu > 80
+                  ? "error"
+                  : pluginMetrics.cpu > 60
+                    ? "warning"
+                    : "success",
+            },
+            {
+              label: "Memory",
+              metric_value: pluginMetrics.memory_mb,
+              percentage_value: pluginMetrics.memory_percent,
+              unit: "%",
+              color:
+                pluginMetrics.memory_mb > 80
+                  ? "error"
+                  : pluginMetrics.memory_mb > 60
+                    ? "warning"
+                    : "primary",
+            },
+          ].map(({ label, metric_value, percentage_value, unit, color }) => (
+            <div key={label} style={{ flex: 1 }}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  marginBottom: 4,
+                }}
+              >
+                <span style={{ fontSize: 11, color: "#6b7280" }}>
+                  {metric_value ? `${label} (${metric_value} MB)` : label}
+                </span>
+                <span style={{ fontSize: 11, fontWeight: 600 }}>
+                  {percentage_value}
+                  {unit}
+                </span>
+              </div>
+              <LinearProgress
+                variant="determinate"
+                value={Math.min(percentage_value, 100)}
+                color={color}
+                sx={{ height: 6, borderRadius: 99 }}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div
+        style={{
+          padding: "8px 24px",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          background: "white",
+          borderBottom: "1px solid #e5e7eb",
+        }}
+      >
+        <span style={{ fontSize: 13, fontWeight: 600, marginRight: 4 }}>
+          Logs
+        </span>
+        {["ALL", ...LEVELS].map((lvl) => (
+          <Chip
+            key={lvl}
+            label={lvl}
+            size="small"
+            color={lvl === "ALL" ? "default" : LEVEL_COLORS[lvl]}
+            variant={filter === lvl ? "filled" : "outlined"}
+            onClick={() => setFilter(lvl)}
+            sx={{ fontSize: 10, height: 22, cursor: "pointer" }}
+          />
+        ))}
+        <span style={{ fontSize: 11, color: "#9ca3af", margin: "0 4px" }}>
+          |
+        </span>
+        {["ALL", ...CATEGORIES].map((cat) => (
+          <Chip
+            key={cat}
+            label={cat}
+            size="small"
+            color="default"
+            variant={categoryFilter === cat ? "filled" : "outlined"}
+            onClick={() => setCategoryFilter(cat)}
+            sx={{ fontSize: 10, height: 22, cursor: "pointer" }}
+          />
+        ))}
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={() => setPaused((p) => !p)}
+          style={{
+            fontSize: 11,
+            cursor: "pointer",
+            background: "none",
+            border: "none",
+            color: paused ? "#d97706" : "#6b7280",
+          }}
+        >
+          {paused ? "Resume" : "Pause"}
+        </button>
+        <button
+          onClick={() => setLogs([])}
+          style={{
+            fontSize: 11,
+            cursor: "pointer",
+            background: "none",
+            border: "none",
+            color: "#6b7280",
+          }}
+        >
+          Clear
+        </button>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          alignItems: error ? "center" : "stretch",
+          justifyContent: error ? "center" : "flex-start",
+          overflowY: "auto",
+        }}
+      >
+        {error ? (
+          <span
+            style={{
+              padding: "12px 20px",
+              backgroundColor: "#fef2f2",
+              color: "#b91c1c",
+              border: "1px solid #fecaca",
+              borderRadius: "8px",
+              fontSize: "14px",
+              fontWeight: "500",
+              fontFamily: "sans-serif",
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.05)",
+            }}
+          >
+            {error}
+          </span>
+        ) : (
+          <>
+            {filtered.map((log) => (
+              <div
+                key={log.id}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 10,
+                  padding: "6px 24px",
+                  borderBottom: "1px solid #f3f4f6",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "#9ca3af",
+                    fontFamily: "monospace",
+                    flexShrink: 0,
+                  }}
+                >
+                  {log.ts}
+                </span>
+                <Chip
+                  // label={log.level}
+                  label={"RAW"}
+                  size="small"
+                  color={LEVEL_COLORS[log.level]}
+                  sx={{ fontSize: 9, height: 18, flexShrink: 0 }}
+                />
+                {log.context && (
+                  <span
+                    style={{
+                      fontSize: 10,
+                      color: "#9ca3af",
+                      fontFamily: "monospace",
+                      flexShrink: 0,
+                    }}
+                  >
+                    [{log.context.slice(0, 8)}]
+                  </span>
+                )}
+                <span
+                  style={{
+                    fontSize: 11,
+                    fontFamily: "monospace",
+                    color: "#374151",
+                    wordBreak: "break-all",
+                  }}
+                >
+                  {log.message}
+                </span>
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PluginStats;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/components/RegistryEditor.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/components/RegistryEditor.js
@@ -1,0 +1,369 @@
+import React, { useEffect, useState } from "react";
+
+const RegistryEditor = ({ onSave }) => {
+  const STORAGE_KEY = "plugin-marketplace/registries/sources";
+
+  const [registries, setRegistries] = useState([]);
+  const [selected, setSelected] = useState([]);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+
+    if (stored) {
+      const parsed = JSON.parse(stored);
+
+      const normalized = parsed.map((item) =>
+        typeof item === "string"
+          ? { url: item, enabled: true }
+          : { url: item.url || "", enabled: !!item.enabled },
+      );
+
+      setRegistries(normalized);
+      setSelected(normalized.map(() => false));
+    } else {
+      const defaults = [
+        {
+          url: "http://localhost:8081/registry-manifest.json",
+          enabled: true,
+        },
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(defaults));
+      setRegistries(defaults);
+      setSelected(defaults.map(() => false));
+    }
+  }, []);
+
+  const toggleSelect = (index) => {
+    const updated = [...selected];
+    updated[index] = !updated[index];
+    setSelected(updated);
+  };
+
+  const handleUrlChange = (index, value) => {
+    const updated = [...registries];
+    updated[index].url = value;
+    setRegistries(updated);
+  };
+
+  const toggleEnabled = (index) => {
+    const updated = [...registries];
+    updated[index].enabled = !updated[index].enabled;
+    setRegistries(updated);
+  };
+
+  const removeItem = (index) => {
+    setRegistries(registries.filter((_, i) => i !== index));
+    setSelected(selected.filter((_, i) => i !== index));
+  };
+
+  const removeSelected = () => {
+    const filtered = registries.filter((_, i) => !selected[i]);
+    setRegistries(filtered);
+    setSelected(filtered.map(() => false));
+  };
+
+  const addItem = () => {
+    setRegistries([...registries, { url: "", enabled: true }]);
+    setSelected([...selected, false]);
+  };
+
+  const save = () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(registries));
+    setSaved(true);
+    onSave();
+    setTimeout(() => {
+      setSaved(false);
+    }, 1000);
+  };
+
+  const selectedCount = selected.filter(Boolean).length;
+
+  const btnBase = {
+    fontSize: 14,
+    fontWeight: 600,
+    cursor: "pointer",
+    borderRadius: 10,
+    padding: "10px 16px",
+    fontFamily: "inherit",
+    transition: "background 0.15s, border-color 0.15s, color 0.15s",
+  };
+
+  return (
+    <div
+      style={{
+        padding: "28px 32px 32px",
+        maxWidth: 640,
+        margin: "0 auto",
+        fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+        color: "#111827",
+        boxSizing: "border-box",
+      }}
+    >
+      <header style={{ marginBottom: 28 }}>
+        <h2
+          style={{
+            margin: "0 0 10px",
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: "-0.02em",
+            lineHeight: 1.2,
+          }}
+        >
+          Registry sources
+        </h2>
+      </header>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
+        role="list"
+        aria-label="Registry source list"
+      >
+        {registries.map((item, index) => (
+          <div
+            key={index}
+            role="listitem"
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: 14,
+              background: "#fff",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "stretch",
+                gap: 0,
+                borderBottom: "1px solid #f3f4f6",
+              }}
+            >
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 48,
+                  flexShrink: 0,
+                  background: "#fafafa",
+                  cursor: "pointer",
+                  borderRight: "1px solid #f3f4f6",
+                }}
+                title="Select for bulk remove"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected[index] || false}
+                  onChange={() => toggleSelect(index)}
+                  aria-label={`Select registry row ${index + 1} for bulk remove`}
+                />
+              </label>
+              <div style={{ flex: 1, padding: "14px 16px 12px", minWidth: 0 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 10,
+                    marginBottom: 8,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 700,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.06em",
+                      color: "#9ca3af",
+                    }}
+                  >
+                    Source {index + 1}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeItem(index)}
+                    style={{
+                      ...btnBase,
+                      padding: "6px 12px",
+                      fontSize: 13,
+                      background: "transparent",
+                      border: "1px solid transparent",
+                      color: "#dc2626",
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+                <label
+                  htmlFor={`registry-url-${index}`}
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: "#374151",
+                    display: "block",
+                    marginBottom: 6,
+                  }}
+                >
+                  Manifest URL
+                </label>
+                <input
+                  id={`registry-url-${index}`}
+                  type="text"
+                  value={item.url}
+                  onChange={(e) => handleUrlChange(index, e.target.value)}
+                  placeholder="https://example.com/registry-manifest.json"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={{
+                    width: "100%",
+                    boxSizing: "border-box",
+                    padding: "10px 12px",
+                    borderRadius: 10,
+                    border: "1px solid #d1d5db",
+                    fontSize: 14,
+                    outline: "none",
+                  }}
+                />
+              </div>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                flexWrap: "wrap",
+                gap: 12,
+                padding: "12px 16px 14px 64px",
+                background: "#fafafa",
+              }}
+            >
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  cursor: "pointer",
+                  userSelect: "none",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={item.enabled}
+                  onChange={() => toggleEnabled(index)}
+                  aria-label={`Active for source ${index + 1}`}
+                />
+                <span>
+                  <span
+                    style={{
+                      display: "block",
+                      fontSize: 14,
+                      fontWeight: 600,
+                      color: "#111827",
+                    }}
+                  >
+                    Active
+                  </span>
+                  <span style={{ fontSize: 12, color: "#6b7280" }}>
+                    When inactive, this URL is not queried
+                  </span>
+                </span>
+              </label>
+              <span
+                style={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  padding: "4px 10px",
+                  borderRadius: 99,
+                  background: item.enabled ? "#dcfce7" : "#f3f4f6",
+                  color: item.enabled ? "#166534" : "#6b7280",
+                }}
+                aria-live="polite"
+              >
+                {item.enabled ? "Active" : "Paused"}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {registries.length === 0 && (
+        <p
+          style={{
+            margin: "20px 0 0",
+            fontSize: 14,
+            color: "#6b7280",
+            textAlign: "center",
+            padding: 24,
+            border: "1px dashed #d1d5db",
+            borderRadius: 14,
+            background: "#fafafa",
+          }}
+        >
+          No sources yet. Use &quot;Add source&quot; below to add a registry
+          URL.
+        </p>
+      )}
+
+      <footer
+        style={{
+          marginTop: 24,
+          paddingTop: 20,
+          borderTop: "1px solid #e5e7eb",
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 10,
+        }}
+      >
+        <button
+          type="button"
+          onClick={addItem}
+          style={{
+            ...btnBase,
+            background: "#fff",
+            border: "1px solid #d1d5db",
+            color: "#374151",
+          }}
+        >
+          Add source
+        </button>
+        <button
+          type="button"
+          onClick={removeSelected}
+          disabled={selectedCount === 0}
+          style={{
+            ...btnBase,
+            background: selectedCount === 0 ? "#f9fafb" : "#fff",
+            border: `1px solid ${selectedCount === 0 ? "#e5e7eb" : "#fecaca"}`,
+            color: selectedCount === 0 ? "#9ca3af" : "#b91c1c",
+            cursor: selectedCount === 0 ? "not-allowed" : "pointer",
+          }}
+        >
+          Remove selected{selectedCount > 0 ? ` (${selectedCount})` : ""}
+        </button>
+        <div style={{ flex: 1, minWidth: 8 }} />
+        <button
+          type="button"
+          onClick={save}
+          style={{
+            ...btnBase,
+            background: saved ? "#008000" : "#4f46e5",
+            border: "1px solid #4338ca",
+            color: "#fff",
+            paddingLeft: 22,
+            paddingRight: 22,
+          }}
+        >
+          {saved ? "Saved" : "Save changes"}
+        </button>
+      </footer>
+    </div>
+  );
+};
+
+export default RegistryEditor;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/components/ZipInstall.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/components/ZipInstall.js
@@ -1,0 +1,390 @@
+import React, { useState, useEffect } from "react";
+import usePluginInstall from "../hooks/usePluginInstall";
+
+const EMPTY_FORM = {
+  name: "",
+  slug: "",
+  version: "",
+  description: "",
+  feExposedModule: "",
+  apiPrefix: "",
+  minPyVersion: "",
+  downloadLink: "",
+  readme_link: "",
+  repository_link: "",
+  thumbnail: "",
+  authorThumbnail: ""
+
+};
+
+const ZipInstall = ({ onInstallComplete }) => {
+  const [form, setForm] = useState(EMPTY_FORM);
+  const { install, reset, progress, status, error, installing } =
+    usePluginInstall({
+      onInstallComplete,
+    });
+
+  const handleChange = (field) => (e) =>
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  const isValid =
+    form.name.trim() &&
+    form.slug.trim() &&
+    form.feExposedModule.trim() &&
+    form.apiPrefix.trim() &&
+    form.downloadLink.trim();
+
+  const handleInstall = () => {
+    if (!isValid || installing) return;
+    install({
+      core: {
+        name: form.name.trim(),
+        slug: form.slug.trim(),
+        version: form.version.trim(),
+        description: form.description.trim(),
+        manifest: {
+          minPyVersion: form.minPyVersion.trim(),
+          feExposedModule: form.feExposedModule.trim(),
+          api_prefix: form.apiPrefix.trim(),
+        },
+      },
+      download_link: form.downloadLink.trim(),
+      readme_link: form.readme_link.trim(),
+      repository_link: form.repository_link.trim(),
+      thumbnail: form.thumbnail.trim(),
+      authorThumbnail: form.authorThumbnail.trim()
+    });
+  };
+
+  const handleReset = () => {
+    reset();
+    setForm(EMPTY_FORM);
+  };
+
+  const statusColor = {
+    installing: "#2563eb",
+    enabling: "#7c3aed",
+    complete: "#16a34a",
+    failed: "#dc2626",
+    cancelled: "#9ca3af",
+  }[status];
+
+  const statusLabel = {
+    installing: "Installing…",
+    enabling: "Enabling plugin…",
+    complete: "Installed and enabled",
+    failed: `Failed: ${error}`,
+    cancelled: "Cancelled",
+  }[status];
+
+  return (
+    <div style={panelStyle}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          marginBottom: "4px",
+        }}
+      >
+        <div>
+          <h2
+            style={{
+              margin: 0,
+              fontSize: "16px",
+              fontWeight: "700",
+              color: "#111827",
+            }}
+          >
+            Install from ZIP
+          </h2>
+          <p style={{ margin: "2px 0 0", fontSize: "13px", color: "#6b7280" }}>
+            Provide plugin details and a direct download URL to a ZIP file.
+          </p>
+        </div>
+        {status && (
+          <button onClick={handleReset} style={resetBtnStyle} title="Reset">
+            ✕
+          </button>
+        )}
+      </div>
+
+      <div
+        style={{
+          marginTop: "16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "10px",
+        }}
+      >
+        <div style={rowStyle}>
+          <Field
+            label="Name"
+            placeholder="chat-plugin"
+            value={form.name}
+            onChange={handleChange("name")}
+            disabled={installing}
+          />
+          <Field
+            label="Slug"
+            placeholder="dev/chat-plugin"
+            value={form.slug}
+            onChange={handleChange("slug")}
+            disabled={installing}
+          />
+        </div>
+        <div style={rowStyle}>
+          <Field
+            label="FE Exposed Module"
+            placeholder="MCPPage.js"
+            value={form.feExposedModule}
+            onChange={handleChange("feExposedModule")}
+            disabled={installing}
+          />
+          <Field
+            label="API Prefix"
+            placeholder="/anylogmcp"
+            value={form.apiPrefix}
+            onChange={handleChange("apiPrefix")}
+            disabled={installing}
+          />
+        </div>
+        <Field
+          label="Description"
+          placeholder="Short description of the plugin"
+          value={form.description}
+          onChange={handleChange("description")}
+          disabled={installing}
+          optional
+        />
+
+        <Field
+          label="README"
+          placeholder="URL Link to PLUGIN.MD file"
+          value={form.readme_link}
+          onChange={handleChange("readme_link")}
+          disabled={installing}
+          optional
+        />
+
+        <Field
+          label="thumbnail"
+          placeholder="URL Link to plugin thumbnail"
+          value={form.thumbnail}
+          onChange={handleChange("thumbnail")}
+          disabled={installing}
+          optional
+        />
+
+        <Field
+          label="Description"
+          placeholder="Short description of the plugin"
+          value={form.description}
+          onChange={handleChange("description")}
+          disabled={installing}
+          optional
+        />
+        <div style={{ ...rowStyle, alignItems: "flex-end" }}>
+          <Field
+            label="Download URL"
+            placeholder="http://localhost:8081/chat-plugin.zip"
+            value={form.downloadLink}
+            onChange={handleChange("downloadLink")}
+            disabled={installing}
+            style={{ flex: 3 }}
+          />
+          <button
+            onClick={handleInstall}
+            disabled={!isValid || installing}
+            style={installBtnStyle(!isValid || installing)}
+          >
+            {installing ? (
+              <span
+                style={{ display: "flex", alignItems: "center", gap: "6px" }}
+              >
+                <Spinner color="#fff" /> Installing…
+              </span>
+            ) : (
+              "Install"
+            )}
+          </button>
+        </div>
+      </div>
+
+      {status && (
+        <div
+          style={{
+            marginTop: "16px",
+            paddingTop: "14px",
+            borderTop: "1px solid #f3f4f6",
+          }}
+        >
+          <div
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "6px",
+              fontSize: "13px",
+              fontWeight: "600",
+              color: statusColor,
+              marginBottom: progress.length > 0 ? "10px" : 0,
+            }}
+          >
+            {installing && <Spinner color={statusColor} />}
+            {statusLabel}
+          </div>
+          {progress.length > 0 && (
+            <div
+              style={{ display: "flex", flexDirection: "column", gap: "5px" }}
+            >
+              {progress.map((msg, i) => {
+                const isLast = i === progress.length - 1 && installing;
+                const isDone = status === "complete" || i < progress.length - 1;
+                return (
+                  <div
+                    key={i}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
+                      fontSize: "13px",
+                      color: isLast ? "#111827" : "#6b7280",
+                      fontWeight: isLast ? "600" : "400",
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: "7px",
+                        height: "7px",
+                        borderRadius: "50%",
+                        flexShrink: 0,
+                        backgroundColor: isDone
+                          ? "#16a34a"
+                          : isLast
+                            ? statusColor
+                            : "#d1d5db",
+                      }}
+                    />
+                    {msg}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Field = ({
+  label,
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  optional,
+  style,
+}) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      gap: "4px",
+      flex: 1,
+      ...style,
+    }}
+  >
+    <label style={{ fontSize: "12px", fontWeight: "600", color: "#374151" }}>
+      {label}
+      {optional && (
+        <span
+          style={{ fontWeight: "400", color: "#9ca3af", marginLeft: "4px" }}
+        >
+          (optional)
+        </span>
+      )}
+    </label>
+    <input
+      type="text"
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      style={{
+        padding: "9px 12px",
+        borderRadius: "8px",
+        border: "1px solid #e5e7eb",
+        fontSize: "13px",
+        outline: "none",
+        backgroundColor: disabled ? "#f9fafb" : "#fff",
+        color: "#111827",
+        boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+        width: "100%",
+        boxSizing: "border-box",
+      }}
+    />
+  </div>
+);
+
+const Spinner = ({ color = "#2563eb" }) => {
+  useEffect(() => {
+    if (!document.getElementById("zip-panel-spin")) {
+      const s = document.createElement("style");
+      s.id = "zip-panel-spin";
+      s.textContent = `@keyframes zip-spin { to { transform: rotate(360deg); } }`;
+      document.head.appendChild(s);
+    }
+  }, []);
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: "11px",
+        height: "11px",
+        border: `2px solid ${color}33`,
+        borderTopColor: color,
+        borderRadius: "50%",
+        animation: "zip-spin 0.7s linear infinite",
+        flexShrink: 0,
+      }}
+    />
+  );
+};
+
+const panelStyle = {
+  backgroundColor: "#fff",
+  border: "1px solid #e5e7eb",
+  borderRadius: "16px",
+  padding: "20px 24px",
+  marginBottom: "28px",
+  boxShadow: "0 1px 4px rgba(0,0,0,0.06)",
+};
+const rowStyle = { display: "flex", gap: "12px", flexWrap: "wrap" };
+const installBtnStyle = (disabled) => ({
+  padding: "9px 22px",
+  borderRadius: "8px",
+  border: "none",
+  backgroundColor: disabled ? "#e5e7eb" : "#111827",
+  color: disabled ? "#9ca3af" : "#fff",
+  fontWeight: "600",
+  fontSize: "13px",
+  cursor: disabled ? "not-allowed" : "pointer",
+  whiteSpace: "nowrap",
+  alignSelf: "flex-end",
+  height: "38px",
+  display: "flex",
+  alignItems: "center",
+});
+const resetBtnStyle = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  color: "#9ca3af",
+  fontSize: "16px",
+  padding: "2px 6px",
+  borderRadius: "6px",
+  lineHeight: 1,
+};
+
+export default ZipInstall;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/hooks/useDownloadManager.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/hooks/useDownloadManager.js
@@ -1,0 +1,40 @@
+import { useState, useCallback } from "react";
+
+const useDownloadManager = () => {
+  const [installs, setInstalls] = useState([]);
+
+  const addInstall = useCallback((slug, name) => {
+    setInstalls((prevInstalls) => [
+      ...prevInstalls.filter((install) => install.slug !== slug),
+      { slug, name, status: null, progress: [], error: null },
+    ]);
+  }, []);
+
+  const updateInstall = useCallback((slug, patch) => {
+    setInstalls((prevInstalls) =>
+      prevInstalls.map((install) => {
+        if (install.slug !== slug) return install;
+        const { progress_step, ...otherFields } = patch;
+        return {
+          ...install,
+          ...otherFields,
+          progress: progress_step
+            ? [...install.progress, progress_step]
+            : (otherFields.progress ?? install.progress),
+        };
+      })
+    );
+  }, []);
+
+  const removeInstall = useCallback((slug) => {
+    setInstalls((prevInstalls) => prevInstalls.filter((install) => install.slug !== slug));
+  }, []);
+
+  const activeCount = installs.filter(
+    (install) => install.status === "installing" || install.status === "enabling"
+  ).length;
+
+  return { installs, addInstall, updateInstall, removeInstall, activeCount };
+};
+
+export default useDownloadManager;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/hooks/usePluginInstall.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/hooks/usePluginInstall.js
@@ -1,0 +1,102 @@
+import { useRef, useCallback, useEffect } from "react";
+import {
+  installPlugin,
+  enablePlugin,
+  getPluginStatus,
+} from "../marketplace_api";
+
+const POLL_INTERVAL_MS = 1500;
+
+const usePluginInstall = () => {
+  const pollRefs = useRef({});
+
+  const stopPolling = (slug) => {
+    if (pollRefs.current[slug]) {
+      clearInterval(pollRefs.current[slug]);
+      delete pollRefs.current[slug];
+    }
+  };
+
+  const enable = useCallback(
+    async (slug, onStatusChange, onInstallComplete) => {
+      onStatusChange(slug, { status: "enabling" });
+      onStatusChange(slug, { progress_step: "Enabling plugin" });
+      try {
+        await enablePlugin(slug);
+        onStatusChange(slug, {
+          progress_step: "Plugin ready",
+          status: "complete",
+        });
+        onInstallComplete?.();
+      } catch (e) {
+        onStatusChange(slug, {
+          status: "failed",
+          error: `Enable failed: ${e.message}`,
+        });
+      }
+    },
+    [],
+  );
+
+  const pollStatus = useCallback(
+    async (slug, onStatusChange, onInstallComplete) => {
+      try {
+        const data = await getPluginStatus(slug);
+
+        if (data.progress) onStatusChange(slug, { progress: data.progress });
+
+        if (data.status === "complete") {
+          stopPolling(slug);
+          try {
+            await enable(slug, onStatusChange, onInstallComplete);
+          } catch (e) {
+            onStatusChange(slug, {
+              status: "failed",
+              error: `Enable failed: ${e.message}`,
+            });
+          }
+        } else if (data.status === "failed") {
+          onStatusChange(slug, {
+            status: "failed",
+            error: data.error || "Unknown error",
+          });
+          stopPolling(slug);
+        } else if (data.status === "cancelled") {
+          onStatusChange(slug, { status: "cancelled" });
+          stopPolling(slug);
+        }
+      } catch (e) {
+        console.warn("Poll error:", e);
+      }
+    },
+    [enable],
+  );
+
+  const install = useCallback(
+    async (plugin, { onStatusChange, onInstallComplete } = {}) => {
+      const slug = plugin.core.slug;
+      onStatusChange(slug, { status: "installing", progress: [], error: null });
+      try {
+        await installPlugin(plugin);
+        pollRefs.current[slug] = setInterval(
+          () => pollStatus(slug, onStatusChange, onInstallComplete),
+          POLL_INTERVAL_MS,
+        );
+      } catch (e) {
+        onStatusChange(slug, { status: "failed", error: e.message });
+      }
+    },
+    [pollStatus],
+  );
+
+  useEffect(
+    () => () => {
+      Object.values(pollRefs.current).forEach(clearInterval);
+    },
+    [],
+  );
+
+  return { install };
+};
+
+export default usePluginInstall;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/hooks/useRegistry.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/hooks/useRegistry.js
@@ -1,0 +1,82 @@
+import { useState, useCallback } from "react";
+import { fetchRegistry, fetchRegistryPaginated } from "../marketplace_api";
+
+const useRegistry = () => {
+  const [plugins, setPlugins] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [hasMore, setHasMore] = useState(true);
+
+  const allPlugins = useCallback(() => Object.values(plugins).flat(), [plugins]);
+  const getPlugins = (key) => plugins[key];
+
+  const setPluginResults = useCallback((key, value) => {
+    setPlugins((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const fetchPlugins = useCallback(async (source) => {
+    if (!source) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const registryPlugins = await fetchRegistry(source);
+      console.log(
+        `Fetched ${registryPlugins.length} plugin manifests from ${source}`,
+      );
+      console.log(JSON.stringify(registryPlugins));
+      setPluginResults(source, registryPlugins);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [setPluginResults]);
+
+  const fetchPluginsPaginated = useCallback(async (source, page = 0) => {
+    if (!source) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const incoming = await fetchRegistryPaginated(source, page);
+      setPluginResults(source, incoming);
+      setHasMore(incoming.length > 0);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [setPluginResults]);
+
+  const removeSource = useCallback((key) => {
+    setPlugins((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
+  const resetSources = useCallback((validSources) => {
+    setPlugins((prev) => {
+      const next = {};
+      validSources.forEach((src) => {
+        if (prev[src]) next[src] = prev[src];
+      });
+      return next;
+    });
+  }, []);
+
+  return {
+    plugins,
+    loading,
+    error,
+    hasMore,
+    fetchPlugins,
+    fetchPluginsPaginated,
+    getPlugins,
+    allPlugins,
+    removeSource,
+    resetSources,
+  };
+};
+
+export default useRegistry;

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/marketplace_api.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/marketplace_api.js
@@ -1,0 +1,55 @@
+// const API_URL = window._env_?.REACT_APP_API_URL || "http://localhost:8000";
+const API_URL = window._env_?.VITE_API_URL || "http://localhost:8080";
+
+const get = async (path) => {
+  const res = await fetch(`${API_URL}/${path}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+};
+
+const patch = async (path, body) => {
+  const res = await fetch(`${API_URL}/${path}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+  return data;
+};
+
+const post = async (path, body) => {
+  const res = await fetch(`${API_URL}/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+  return data;
+};
+
+export const fetchRegistry = async (source) => {
+  const res = await fetch(source, { cache: "no-store" });
+  if (!res.ok) throw new Error(`Registry responded with ${res.status}`);
+  const data = await res.json();
+  return data.plugins ?? [];
+};
+
+export const fetchRegistryPaginated = async (source, page = 0) => {
+  const url = new URL(source);
+  url.searchParams.set("page", page);
+  const res = await fetch(url.toString(), { cache: "no-store" });
+  if (!res.ok) throw new Error(`Registry responded with ${res.status}`);
+  const data = await res.json();
+  return Array.isArray(data) ? data : (data.plugins ?? []);
+};
+
+export const getInstalledPlugins = () => get("plugins");
+export const getPluginStatus = (slug) =>
+  get(`plugins/status/${encodeURIComponent(slug)}`);
+
+export const installPlugin = (plugin) => post("plugins/install", { plugin });
+export const uninstallPlugin = (slug) => post("plugins/uninstall", { slug });
+export const enablePlugin = (slug) => patch("plugins/enable", { slug });
+export const disablePlugin = (slug) => patch("plugins/disable", { slug });

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/styles/MarketplacePage.css
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/styles/MarketplacePage.css
@@ -1,0 +1,340 @@
+.mp-page {
+  padding: 40px;
+  min-height: 100vh;
+  font-family: "Inter", sans-serif;
+  background-color: #f9fafb;
+}
+
+.mp-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.mp-header-text h1 {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 800;
+  color: #111827;
+  letter-spacing: -0.5px;
+}
+
+.mp-header-text p {
+  margin: 4px 0 0;
+  font-size: 15px;
+  color: #6b7280;
+}
+
+.mp-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.mp-tab-group {
+  display: flex;
+  gap: 6px;
+  background: #f3f4f6;
+  padding: 4px;
+  border-radius: 99px;
+  border: 1px solid #e5e7eb;
+  flex-shrink: 0;
+}
+
+.mp-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 18px;
+  border: none;
+  border-radius: 99px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, box-shadow 0.15s;
+  background: transparent;
+  color: #6b7280;
+  letter-spacing: 0.03em;
+}
+
+.mp-tab:hover {
+  color: #374151;
+  background: #e9eaec;
+}
+
+.mp-tab--active {
+  background: #ffffff;
+  color: #111827;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+.mp-tab-count {
+  font-size: 11px;
+  font-weight: 700;
+  background: #6366f1;
+  color: #fff;
+  padding: 1px 7px;
+  border-radius: 99px;
+  min-width: 18px;
+  text-align: center;
+}
+
+.mp-search {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid #e5e7eb;
+  outline: none;
+  font-size: 14px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  min-width: 160px;
+}
+
+.mp-search:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px #eef2ff;
+}
+
+.mp-install-btn.MuiButton-root {
+  border-radius: 14px !important;
+  text-transform: none !important;
+  font-size: 14px !important;
+  border-color: #e5e7eb !important;
+  color: #374151 !important;
+  white-space: nowrap;
+  padding: 9px 18px !important;
+  flex-shrink: 0;
+}
+
+.mp-install-btn.MuiButton-root:hover {
+  background-color: #f3f4f6 !important;
+  border-color: #d1d5db !important;
+}
+
+.mp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.mp-empty {
+  color: #9ca3af;
+  font-size: 14px;
+  padding: 48px 0;
+  text-align: center;
+}
+
+.mp-updates-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  border-radius: 14px;
+  border: 1px solid #fde68a;
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+  color: #92400e;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.mp-updates-banner span {
+  font-weight: 500;
+  color: #b45309;
+}
+
+.mp-plugin-update-row {
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mp-plugin-update-meta {
+  font-size: 12px;
+  color: #92400e;
+  font-weight: 500;
+}
+
+.mp-plugin-update-btn {
+  width: 100%;
+  padding: 10px;
+  border-radius: 10px;
+  border: none;
+  background: #d97706;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.15s;
+}
+
+.mp-plugin-update-btn:hover {
+  background: #b45309;
+}
+
+.mp-plugin-update-btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.plugin-bubble {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  transition: box-shadow 0.15s, border-color 0.15s;
+}
+
+.plugin-bubble:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+}
+
+.plugin-bubble--active {
+  border-color: #a5b4fc;
+  box-shadow: 0 0 0 3px #eef2ff;
+}
+
+/* ── Thumb row ───────────────────────────────────────────────────────────── */
+
+.thumb-container {
+  padding: 16px 16px 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.plugin-thumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.plugin-thumb-placeholder {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  background: #6366f1;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.version-tag {
+  font-size: 11px;
+  font-weight: 600;
+  color: #64748b;
+  background: #f1f5f9;
+  padding: 2px 8px;
+  border-radius: 99px;
+}
+
+.mp-enabled-badge {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  background: #22c55e;
+  padding: 2px 9px;
+  border-radius: 99px;
+}
+
+.plugin-content {
+  padding: 12px 16px 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.plugin-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #0f172a;
+  margin: 0;
+}
+
+.plugin-desc {
+  font-size: 13px;
+  color: #64748b;
+  margin: 0;
+  line-height: 1.5;
+  flex: 1;
+}
+
+.mp-error {
+  font-size: 12px;
+  color: #ef4444;
+  margin: 0;
+}
+
+.plugin-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.btn-download {
+  padding: 7px 16px;
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-download:hover {
+  background: #4f46e5;
+}
+
+.btn-uninstall {
+  background: transparent;
+  color: #ef4444;
+  border: 1.5px solid #ef4444;
+}
+
+.btn-uninstall:hover {
+  background: #fff0f0;
+}
+
+.btn-link {
+  font-size: 12px;
+  color: #6366f1;
+  text-decoration: none;
+  font-weight: 500;
+  margin-left: auto;
+}
+
+.btn-link:hover {
+  text-decoration: underline;
+}
+
+.mp-loader,
+.loader {
+  padding: 48px 32px;
+  color: #64748b;
+  font-size: 14px;
+}

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/utils/installedDisplay.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/utils/installedDisplay.js
@@ -1,0 +1,25 @@
+import { versionToString } from "./versionUtils";
+
+/**
+ * Build marketplace-shaped plugin object from GET /plugins
+ */
+export function installedRecordToDisplayPlugin(inst) {
+  if (!inst?.slug) return null;
+  return {
+    core: {
+      id: inst.id,
+      name: inst.name || inst.slug,
+      slug: inst.slug,
+      version: versionToString(inst.version),
+      description:
+        inst.description ||
+        "Installed on this host. Add a registry that lists this plugin to see marketplace metadata.",
+      manifest: inst.manifest,
+    },
+    thumbnail: inst.thumbnail || null,
+    readme_link: inst.readme_link || null,
+    download_link: inst.download_link || null,
+    repository_link: inst.repository_link || null,
+    _syntheticFromInstall: true,
+  };
+}

--- a/CLI/local-cli-fe-full/src/plugins/marketplace/utils/versionUtils.js
+++ b/CLI/local-cli-fe-full/src/plugins/marketplace/utils/versionUtils.js
@@ -1,0 +1,58 @@
+export const versionToTuple = (v) => {
+  if (v == null) return [0, 0, 0];
+  if (
+    typeof v === "object" &&
+    v !== null &&
+    "major" in v &&
+    "minor" in v &&
+    "patch" in v
+  ) {
+    return [
+      Number(v.major) || 0,
+      Number(v.minor) || 0,
+      Number(v.patch) || 0,
+    ];
+  }
+  const s = String(v).trim();
+  const m = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(s); // Parses version string
+  if (!m) return [0, 0, 0];
+  return [
+    parseInt(m[1], 10) || 0,
+    parseInt(m[2] ?? "0", 10) || 0,
+    parseInt(m[3] ?? "0", 10) || 0,
+  ];
+}
+
+/** @param {unknown} v */
+export function versionToString(v) {
+  const t = versionToTuple(v);
+  return `${t[0]}.${t[1]}.${t[2]}`;
+}
+
+/** Positive if higher, negative if lower0 if equal. */
+export const compareVersions = (a, b) =>{
+  const ta = versionToTuple(a);
+  const tb = versionToTuple(b);
+  for (let i = 0; i < 3; i += 1) {
+    if (ta[i] !== tb[i]) return ta[i] - tb[i];
+  }
+  return 0;
+}
+
+/**
+ * From registry buckets keyed by URL, pick the newest plugin manifest per slug
+ * (highest semantic version).
+ */
+export function mergeLatestRegistryPluginsBySlug(pluginsBySource) {
+  const map = new Map();
+  const flat = Object.values(pluginsBySource || {}).flat();
+  for (const p of flat) {
+    const slug = p?.core?.slug;
+    if (!slug) continue;
+    const cur = map.get(slug);
+    if (!cur || compareVersions(p.core.version, cur.core.version) > 0) {
+      map.set(slug, p);
+    }
+  }
+  return map;
+}

--- a/CLI/local-cli-fe-full/src/plugins/mcpclient/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/mcpclient/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/nodecheck/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/nodecheck/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/policycreator/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/policycreator/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/reportgenerator/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/reportgenerator/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/sshclient/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/sshclient/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/uns/UNSPage.js
+++ b/CLI/local-cli-fe-full/src/plugins/uns/UNSPage.js
@@ -1,7 +1,19 @@
-import React, { useState, useEffect, useRef } from 'react';
-import './UNSPage.css';
-import UNSSidePanel from './UNSSidePanel';
-import { getRoot, getChildren, checkChildren, queryTable, checkTable } from './uns_api';
+import React, { useState, useEffect, useRef } from "react";
+import "./UNSPage.css";
+import UNSSidePanel from "./UNSSidePanel";
+import {
+  getRoot,
+  getChildren,
+  checkChildren,
+  queryTable,
+  checkTable,
+} from "./uns_api";
+
+// const UNSPage = () => {
+//   return <>UNS</>;
+// };
+
+// export default UNSPage;
 
 const UNSPage = ({ node }) => {
   const [loading, setLoading] = useState(false);
@@ -16,10 +28,10 @@ const UNSPage = ({ node }) => {
   const [hoverTimeout, setHoverTimeout] = useState(null);
   const [selectedItem, setSelectedItem] = useState(null); // Selected item for side panel
   const [isSidePanelOpen, setIsSidePanelOpen] = useState(false); // Side panel visibility
-  const [rootQuery, setRootQuery] = useState('blockchain get root policies'); // Configurable root query
+  const [rootQuery, setRootQuery] = useState("blockchain get root policies"); // Configurable root query
   const [timeRangeValue, setTimeRangeValue] = useState(5); // Time range value (default 5)
-  const [timeRangeUnit, setTimeRangeUnit] = useState('minute'); // Time range unit (default: minute)
-  const [timeColumn, setTimeColumn] = useState('insert_timestamp'); // Time column: insert_timestamp or timestamp
+  const [timeRangeUnit, setTimeRangeUnit] = useState("minute"); // Time range unit (default: minute)
+  const [timeColumn, setTimeColumn] = useState("insert_timestamp"); // Time column: insert_timestamp or timestamp
   const [sqlData, setSqlData] = useState(null); // SQL query results
   const [sqlLoading, setSqlLoading] = useState(false); // SQL query loading state
   const [sqlError, setSqlError] = useState(null); // SQL query error
@@ -47,17 +59,16 @@ const UNSPage = ({ node }) => {
     };
   }, [hoverTimeout]);
 
-
   // Background check for table data when layers change
   useEffect(() => {
     // Cancel all pending checks from previous layers
-    checkTimeoutsRef.current.forEach(timeoutId => {
+    checkTimeoutsRef.current.forEach((timeoutId) => {
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
     });
     checkTimeoutsRef.current = [];
-    
+
     // Clear checking state for items not in current layer
     if (layers.length === 0 || !node) {
       setCheckingData(new Set());
@@ -82,7 +93,7 @@ const UNSPage = ({ node }) => {
     }
 
     // Clear checking state for items not in current layer
-    setCheckingData(prev => {
+    setCheckingData((prev) => {
       const newSet = new Set();
       for (const key of prev) {
         if (currentLayerCacheKeys.has(key)) {
@@ -100,7 +111,11 @@ const UNSPage = ({ node }) => {
         const cacheKey = `${itemData.dbms}:${itemData.table}`;
         // Only check if not already cached and not currently checking
         if (!itemsWithData.has(cacheKey) && !checkingData.has(cacheKey)) {
-          itemsToCheck.push({ dbms: itemData.dbms, table: itemData.table, cacheKey });
+          itemsToCheck.push({
+            dbms: itemData.dbms,
+            table: itemData.table,
+            cacheKey,
+          });
         }
       }
     }
@@ -109,10 +124,10 @@ const UNSPage = ({ node }) => {
     if (itemsToCheck.length > 0) {
       let index = 0;
       let cancelled = false;
-      
+
       const processNext = () => {
         if (cancelled || index >= itemsToCheck.length) return;
-        
+
         const item = itemsToCheck[index];
         checkTableData(item.dbms, item.table).then(() => {
           if (cancelled) return;
@@ -124,15 +139,15 @@ const UNSPage = ({ node }) => {
           }
         });
       };
-      
+
       // Start processing after a short delay
       const initialTimeoutId = setTimeout(processNext, 100);
       checkTimeoutsRef.current.push(initialTimeoutId);
-      
+
       // Cleanup: cancel pending checks if layers change or component unmounts
       return () => {
         cancelled = true;
-        checkTimeoutsRef.current.forEach(timeoutId => {
+        checkTimeoutsRef.current.forEach((timeoutId) => {
           if (timeoutId) {
             clearTimeout(timeoutId);
           }
@@ -146,13 +161,13 @@ const UNSPage = ({ node }) => {
   // Background check for children when layers change
   useEffect(() => {
     // Cancel all pending children checks from previous layers
-    childrenCheckTimeoutsRef.current.forEach(timeoutId => {
+    childrenCheckTimeoutsRef.current.forEach((timeoutId) => {
       if (timeoutId) {
         clearTimeout(timeoutId);
       }
     });
     childrenCheckTimeoutsRef.current = [];
-    
+
     if (layers.length === 0 || !node) {
       setCheckingChildren(new Set());
       return;
@@ -175,7 +190,7 @@ const UNSPage = ({ node }) => {
     }
 
     // Clear checking state for items not in current layer
-    setCheckingChildren(prev => {
+    setCheckingChildren((prev) => {
       const newSet = new Set();
       for (const itemId of prev) {
         if (currentLayerItemIds.has(itemId)) {
@@ -192,7 +207,11 @@ const UNSPage = ({ node }) => {
       if (itemId) {
         const itemKey = `${layers.length - 1}-${itemId}`;
         // Only check if not already cached and not currently checking
-        if (!itemsWithChildren.has(itemKey) && !itemsWithoutChildren.has(itemKey) && !checkingChildren.has(itemId)) {
+        if (
+          !itemsWithChildren.has(itemKey) &&
+          !itemsWithoutChildren.has(itemKey) &&
+          !checkingChildren.has(itemId)
+        ) {
           itemsToCheck.push({ itemId, itemKey });
         }
       }
@@ -202,10 +221,10 @@ const UNSPage = ({ node }) => {
     if (itemsToCheck.length > 0) {
       let index = 0;
       let cancelled = false;
-      
+
       const processNext = () => {
         if (cancelled || index >= itemsToCheck.length) return;
-        
+
         const item = itemsToCheck[index];
         checkItemChildren(item.itemId, item.itemKey).then(() => {
           if (cancelled) return;
@@ -217,15 +236,15 @@ const UNSPage = ({ node }) => {
           }
         });
       };
-      
+
       // Start processing after a short delay
       const initialTimeoutId = setTimeout(processNext, 100);
       childrenCheckTimeoutsRef.current.push(initialTimeoutId);
-      
+
       // Cleanup: cancel pending checks if layers change or component unmounts
       return () => {
         cancelled = true;
-        childrenCheckTimeoutsRef.current.forEach(timeoutId => {
+        childrenCheckTimeoutsRef.current.forEach((timeoutId) => {
           if (timeoutId) {
             clearTimeout(timeoutId);
           }
@@ -238,12 +257,12 @@ const UNSPage = ({ node }) => {
 
   const loadRootItems = async () => {
     if (!node) {
-      setError('No node selected. Please select a node first.');
+      setError("No node selected. Please select a node first.");
       return;
     }
 
     if (!rootQuery.trim()) {
-      setError('Root query cannot be empty.');
+      setError("Root query cannot be empty.");
       return;
     }
 
@@ -252,59 +271,67 @@ const UNSPage = ({ node }) => {
 
     try {
       const result = await getRoot(node, rootQuery);
-      
+
       if (result.success && result.data) {
         // Log the structure for debugging
-        console.log('UNS: Root items received:', result.data);
+        console.log("UNS: Root items received:", result.data);
         if (result.data.length > 0) {
-          console.log('UNS: First item structure:', result.data[0]);
+          console.log("UNS: First item structure:", result.data[0]);
         }
-        
+
         // Initialize with root layer
         setLayers([result.data]);
         setCurrentPath([]);
         setExpandedItems(new Set());
       } else {
-        setError('Failed to load root items');
+        setError("Failed to load root items");
       }
     } catch (err) {
-      console.error('Error loading root items:', err);
-      setError(err.message || 'Failed to load root items');
+      console.error("Error loading root items:", err);
+      setError(err.message || "Failed to load root items");
     } finally {
       setLoading(false);
     }
   };
 
   const getItemId = (item) => {
-    if (!item || typeof item !== 'object') {
+    if (!item || typeof item !== "object") {
       return null;
     }
-    
+
     // Handle structure: {key: {data}} - find the nested object first
     const keys = Object.keys(item);
-    if (keys.length === 1 && typeof item[keys[0]] === 'object' && !Array.isArray(item[keys[0]])) {
+    if (
+      keys.length === 1 &&
+      typeof item[keys[0]] === "object" &&
+      !Array.isArray(item[keys[0]])
+    ) {
       // This is the {key: {data}} structure
       const nested = item[keys[0]];
       if (nested.id) return nested.id;
     }
-    
+
     // Also check for legacy structures
     if (item.namespace && item.namespace.id) return item.namespace.id;
     if (item.device && item.device.id) return item.device.id;
     if (item.sensor && item.sensor.id) return item.sensor.id;
     if (item.id) return item.id;
-    
+
     return null;
   };
 
   const getItemName = (item) => {
-    if (!item || typeof item !== 'object') {
-      return String(item || 'Unknown');
+    if (!item || typeof item !== "object") {
+      return String(item || "Unknown");
     }
-    
+
     // Handle structure: {key: {data}} - this is the main structure
     const keys = Object.keys(item);
-    if (keys.length === 1 && typeof item[keys[0]] === 'object' && !Array.isArray(item[keys[0]])) {
+    if (
+      keys.length === 1 &&
+      typeof item[keys[0]] === "object" &&
+      !Array.isArray(item[keys[0]])
+    ) {
       // This is the {key: {data}} structure - extract from nested object
       const nested = item[keys[0]];
       // First try 'name' field (preferred)
@@ -312,7 +339,7 @@ const UNSPage = ({ node }) => {
       // Then try 'id' field
       if (nested.id) return nested.id;
     }
-    
+
     // Legacy structures (namespace, device, sensor)
     if (item.namespace) {
       if (item.namespace.name) return item.namespace.name;
@@ -326,76 +353,93 @@ const UNSPage = ({ node }) => {
       if (item.sensor.name) return item.sensor.name;
       if (item.sensor.id) return item.sensor.id;
     }
-    
+
     // Check top-level fields
     if (item.name) return item.name;
     if (item.id) return item.id;
-    
+
     // Check all keys for nested objects that might have name/id
     for (const key of keys) {
-      if (item[key] && typeof item[key] === 'object' && !Array.isArray(item[key])) {
+      if (
+        item[key] &&
+        typeof item[key] === "object" &&
+        !Array.isArray(item[key])
+      ) {
         const nested = item[key];
         if (nested.name) return nested.name;
         if (nested.id) return nested.id;
       }
     }
-    
+
     // Last resort: use the first meaningful string value
     for (const key of keys) {
-      if (typeof item[key] === 'string' && item[key].trim() && key !== 'date' && key !== 'ledger') {
+      if (
+        typeof item[key] === "string" &&
+        item[key].trim() &&
+        key !== "date" &&
+        key !== "ledger"
+      ) {
         return item[key];
       }
     }
-    
+
     // If we have a single key, use that as the name
     if (keys.length === 1) {
       return keys[0];
     }
-    
+
     // Final fallback - use a truncated JSON representation
     const jsonStr = JSON.stringify(item);
     if (jsonStr.length > 0) {
-      return jsonStr.substring(0, 30) + (jsonStr.length > 30 ? '...' : '');
+      return jsonStr.substring(0, 30) + (jsonStr.length > 30 ? "..." : "");
     }
-    
-    return 'Unknown';
+
+    return "Unknown";
   };
 
   const getItemType = (item) => {
-    if (!item || typeof item !== 'object') {
-      return 'unknown';
+    if (!item || typeof item !== "object") {
+      return "unknown";
     }
-    
+
     // Handle structure: {key: {data}} - use the key as the type
     const keys = Object.keys(item);
-    if (keys.length === 1 && typeof item[keys[0]] === 'object' && !Array.isArray(item[keys[0]])) {
+    if (
+      keys.length === 1 &&
+      typeof item[keys[0]] === "object" &&
+      !Array.isArray(item[keys[0]])
+    ) {
       return keys[0]; // Return the key (config, master, license, cluster, operator, table, etc.)
     }
-    
+
     // Legacy structures
-    if (item.namespace) return 'namespace';
-    if (item.device) return 'device';
-    if (item.sensor) return 'sensor';
-    
-    return 'unknown';
+    if (item.namespace) return "namespace";
+    if (item.device) return "device";
+    if (item.sensor) return "sensor";
+
+    return "unknown";
   };
 
   const getItemData = (item) => {
-    if (!item || typeof item !== 'object') {
+    if (!item || typeof item !== "object") {
       return item;
     }
-    
+
     // Handle structure: {key: {data}} - return the nested data object
     const keys = Object.keys(item);
-    if (keys.length === 1 && typeof item[keys[0]] === 'object' && !Array.isArray(item[keys[0]])) {
+    if (
+      keys.length === 1 &&
+      typeof item[keys[0]] === "object" &&
+      !Array.isArray(item[keys[0]])
+    ) {
       return item[keys[0]]; // Return the nested data object
     }
-    
+
     // Legacy structures
     if (item.namespace) return item.namespace;
     if (item.device) return item.device;
     if (item.sensor) return item.sensor;
-    
+
     return item;
   };
 
@@ -410,7 +454,7 @@ const UNSPage = ({ node }) => {
 
   const checkItemChildren = async (itemId, itemKey) => {
     if (!node || !itemId) return false;
-    
+
     // If already cached, return cached value
     if (itemsWithChildren.has(itemKey)) {
       return true;
@@ -418,39 +462,40 @@ const UNSPage = ({ node }) => {
     if (itemsWithoutChildren.has(itemKey)) {
       return false;
     }
-    
+
     // If currently checking, return null (don't check again)
     if (checkingChildren.has(itemId)) {
       return null;
     }
-    
+
     // Mark as checking
-    setCheckingChildren(prev => new Set(prev).add(itemId));
-    
+    setCheckingChildren((prev) => new Set(prev).add(itemId));
+
     try {
       const result = await checkChildren(node, itemId);
-      
+
       // Only consider it has_children if success is True AND has_children is True
-      const hasChildren = result.success === true && result.has_children === true;
-      
+      const hasChildren =
+        result.success === true && result.has_children === true;
+
       // Cache the result
       if (result.success !== undefined) {
         if (hasChildren) {
-          setItemsWithChildren(prev => new Set(prev).add(itemKey));
+          setItemsWithChildren((prev) => new Set(prev).add(itemKey));
         } else {
-          setItemsWithoutChildren(prev => new Set(prev).add(itemKey));
+          setItemsWithoutChildren((prev) => new Set(prev).add(itemKey));
         }
       }
-      
+
       return hasChildren;
     } catch (err) {
-      console.error('Error checking children:', err);
+      console.error("Error checking children:", err);
       // On error, assume no children and cache that
-      setItemsWithoutChildren(prev => new Set(prev).add(itemKey));
+      setItemsWithoutChildren((prev) => new Set(prev).add(itemKey));
       return false;
     } finally {
       // Remove from checking set
-      setCheckingChildren(prev => {
+      setCheckingChildren((prev) => {
         const newSet = new Set(prev);
         newSet.delete(itemId);
         return newSet;
@@ -461,24 +506,24 @@ const UNSPage = ({ node }) => {
   const expandItem = async (item, layerIndex) => {
     const itemId = getItemId(item);
     if (!itemId) {
-      console.log('UNS: Cannot expand item - no ID found:', item);
+      console.log("UNS: Cannot expand item - no ID found:", item);
       return;
     }
 
     const expandedKey = `${layerIndex}-${itemId}`;
-    
+
     // If already expanded, collapse it
     if (expandedItems.has(expandedKey)) {
       const newExpanded = new Set(expandedItems);
       newExpanded.delete(expandedKey);
       setExpandedItems(newExpanded);
-      
+
       // Remove layers after this one
       const newLayers = layers.slice(0, layerIndex + 1);
       setLayers(newLayers);
       setCurrentPath(currentPath.slice(0, layerIndex));
       // Scroll to top when collapsing
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      window.scrollTo({ top: 0, behavior: "smooth" });
       return;
     }
 
@@ -487,26 +532,26 @@ const UNSPage = ({ node }) => {
 
     // Log the command being sent
     const command = `blockchain get * where [id] = "${itemId}" bring.children`;
-    console.log('UNS: Clicking on item:', {
+    console.log("UNS: Clicking on item:", {
       itemId: itemId,
       itemName: getItemName(item),
       itemType: getItemType(item),
       command: command,
-      connection: node
+      connection: node,
     });
 
     try {
       const result = await getChildren(node, itemId);
-      
-      console.log('UNS: Response received:', {
+
+      console.log("UNS: Response received:", {
         success: result.success,
         dataLength: result.data ? result.data.length : 0,
-        hasChildren: result.data && result.data.length > 0
+        hasChildren: result.data && result.data.length > 0,
       });
-      
+
       if (result.success && result.data !== undefined) {
         const children = result.data;
-        
+
         // Cache whether this item has children
         const itemKey = `${layerIndex}-${itemId}`;
         if (children && children.length > 0) {
@@ -514,7 +559,7 @@ const UNSPage = ({ node }) => {
           const newHasChildren = new Set(itemsWithChildren);
           newHasChildren.add(itemKey);
           setItemsWithChildren(newHasChildren);
-          
+
           // Mark as expanded
           const newExpanded = new Set(expandedItems);
           newExpanded.add(expandedKey);
@@ -525,28 +570,33 @@ const UNSPage = ({ node }) => {
           setLayers(newLayers);
 
           // Update path
-          const newPath = [...currentPath.slice(0, layerIndex), {
-            id: itemId,
-            name: getItemName(item),
-            data: getItemData(item)
-          }];
+          const newPath = [
+            ...currentPath.slice(0, layerIndex),
+            {
+              id: itemId,
+              name: getItemName(item),
+              data: getItemData(item),
+            },
+          ];
           setCurrentPath(newPath);
-          
+
           // Scroll to top when expanding to new layer
-          window.scrollTo({ top: 0, behavior: 'smooth' });
+          window.scrollTo({ top: 0, behavior: "smooth" });
         } else {
           // No children - mark as leaf node
-          console.log(`UNS: Item ${itemId} has no children (empty array or undefined)`);
+          console.log(
+            `UNS: Item ${itemId} has no children (empty array or undefined)`,
+          );
           const newNoChildren = new Set(itemsWithoutChildren);
           newNoChildren.add(itemKey);
           setItemsWithoutChildren(newNoChildren);
         }
       } else {
-        setError('Failed to load children');
+        setError("Failed to load children");
       }
     } catch (err) {
-      console.error('Error expanding item:', err);
-      setError(err.message || 'Failed to expand item');
+      console.error("Error expanding item:", err);
+      setError(err.message || "Failed to expand item");
     } finally {
       setLoading(false);
     }
@@ -557,11 +607,11 @@ const UNSPage = ({ node }) => {
     const newLayers = layers.slice(0, targetLayerIndex + 1);
     setLayers(newLayers);
     setCurrentPath(currentPath.slice(0, targetLayerIndex));
-    
+
     // Update expanded items to match - only items in the path up to targetLayerIndex
     const newExpanded = new Set();
     const newHasChildren = new Set();
-    
+
     // Mark items in the path as expanded and having children
     for (let i = 0; i < targetLayerIndex; i++) {
       if (i < currentPath.length) {
@@ -571,15 +621,18 @@ const UNSPage = ({ node }) => {
         newHasChildren.add(key);
       }
     }
-    
+
     setExpandedItems(newExpanded);
     // Merge with existing itemsWithChildren to preserve cache
-    const mergedHasChildren = new Set([...itemsWithChildren, ...newHasChildren]);
+    const mergedHasChildren = new Set([
+      ...itemsWithChildren,
+      ...newHasChildren,
+    ]);
     setItemsWithChildren(mergedHasChildren);
     // Keep itemsWithoutChildren as is - we don't need to clear it
-    
+
     // Scroll to top when navigating
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const handleItemHover = (e, item) => {
@@ -587,13 +640,13 @@ const UNSPage = ({ node }) => {
     if (hoverTimeout) {
       clearTimeout(hoverTimeout);
     }
-    
+
     // Set a timeout to show tooltip after 1 second
     const timeout = setTimeout(() => {
       setHoveredItem(item);
       setHoverPosition({ x: e.clientX, y: e.clientY });
     }, 1000);
-    
+
     setHoverTimeout(timeout);
   };
 
@@ -606,13 +659,47 @@ const UNSPage = ({ node }) => {
     setHoveredItem(null);
   };
 
-  const fetchSqlData = async (dbms, table, whereClause, column, { silent = false } = {}) => {
+  const fetchMetadata = async (dbms, table, whereClause, column) => {
     if (!node || !dbms || !table) return;
 
-    if (!silent) {
-      setSqlLoading(true);
-      setSqlError(null);
+    setMetadataLoading(true);
+    setMetadataError(null);
+
+    try {
+      const result = await queryMetadata(node, {
+        dbms,
+        table,
+        time_value: timeRangeValue,
+        time_unit: timeRangeUnit,
+        where: whereClause,
+        column,
+        time_column: timeColumn,
+      });
+
+      console.log("UNS: Metadata query result:", {
+        success: result.success,
+        dataType: typeof result.data,
+        raw: result,
+      });
+
+      if (result.success) {
+        setMetadata(result.data);
+      } else {
+        setMetadataError(result.error || "Failed to fetch metadata");
+      }
+    } catch (err) {
+      console.error("Error fetching metadata:", err);
+      setMetadataError(err.message || "Failed to fetch metadata");
+    } finally {
+      setMetadataLoading(false);
     }
+  };
+
+  const fetchSqlData = async (dbms, table, whereClause, column) => {
+    if (!node || !dbms || !table) return;
+
+    setSqlLoading(true);
+    setSqlError(null);
 
     try {
       const result = await queryTable(node, {
@@ -624,62 +711,59 @@ const UNSPage = ({ node }) => {
         column,
         time_column: timeColumn,
       });
-      
-      console.log('UNS: SQL query result:', {
+
+      console.log("UNS: SQL query result:", {
         success: result.success,
         dataLength: result.data ? result.data.length : 0,
-        dataType: Array.isArray(result.data) ? 'array' : typeof result.data
+        dataType: Array.isArray(result.data) ? "array" : typeof result.data,
       });
-      
+
       if (result.success) {
-        console.log(`UNS: Setting ${result.data ? result.data.length : 0} rows in state`);
+        console.log(
+          `UNS: Setting ${result.data ? result.data.length : 0} rows in state`,
+        );
         setSqlData(result.data);
-        if (silent) setSqlError(null);
       } else {
-        setSqlError(result.error || 'Failed to fetch table data');
+        setSqlError(result.error || "Failed to fetch table data");
       }
     } catch (err) {
-      console.error('Error fetching SQL data:', err);
-      if (!silent) {
-        setSqlError(err.message || 'Failed to fetch table data');
-      }
+      console.error("Error fetching SQL data:", err);
+      setSqlError(err.message || "Failed to fetch table data");
     } finally {
-      if (!silent) {
-        setSqlLoading(false);
-      }
+      setSqlLoading(false);
     }
   };
 
   const checkTableData = async (dbms, table) => {
     if (!node || !dbms || !table) return false;
-    
+
     // Create a cache key
     const cacheKey = `${dbms}:${table}`;
-    
+
     // If already cached, return cached value
     if (itemsWithData.has(cacheKey)) {
       return itemsWithData.get(cacheKey);
     }
-    
+
     // If currently checking, return null (don't check again)
     if (checkingData.has(cacheKey)) {
       return null;
     }
-    
+
     // Mark as checking
-    setCheckingData(prev => new Set(prev).add(cacheKey));
-    
+    setCheckingData((prev) => new Set(prev).add(cacheKey));
+
     try {
       const result = await checkTable(node, { dbms, table });
-      
+
       // Only consider it has_data if success is True AND has_data is True
       // If success is False or has_data is False, treat as no data
       const hasData = result.success === true && result.has_data === true;
-      
+
       // Only cache if we got a definitive result (true or false)
       // Don't cache errors or undefined states
       if (result.success !== undefined) {
-        setItemsWithData(prev => {
+        setItemsWithData((prev) => {
           const newMap = new Map(prev);
           // Only cache true values - false means no data, don't cache false to allow re-checking
           // Actually, let's cache false too so we don't keep re-checking failed tables
@@ -687,12 +771,12 @@ const UNSPage = ({ node }) => {
           return newMap;
         });
       }
-      
+
       return hasData;
     } catch (err) {
-      console.error('Error checking table data:', err);
+      console.error("Error checking table data:", err);
       // On any error (network, parsing, etc.), assume no data and cache that
-      setItemsWithData(prev => {
+      setItemsWithData((prev) => {
         const newMap = new Map(prev);
         newMap.set(cacheKey, false);
         return newMap;
@@ -700,7 +784,7 @@ const UNSPage = ({ node }) => {
       return false;
     } finally {
       // Remove from checking set
-      setCheckingData(prev => {
+      setCheckingData((prev) => {
         const newSet = new Set(prev);
         newSet.delete(cacheKey);
         return newSet;
@@ -710,8 +794,9 @@ const UNSPage = ({ node }) => {
 
   const toggleSidePanel = (item) => {
     const itemId = getItemId(item);
-    const isCurrentlySelected = selectedItem && getItemId(selectedItem) === itemId;
-    
+    const isCurrentlySelected =
+      selectedItem && getItemId(selectedItem) === itemId;
+
     // If clicking on the already selected item and panel is open, close it
     if (isCurrentlySelected && isSidePanelOpen) {
       setIsSidePanelOpen(false);
@@ -725,15 +810,24 @@ const UNSPage = ({ node }) => {
       setSqlData(null);
       setSqlError(null);
       setChartYKey(null); // Reset so chart defaults to policy column for new item
-      setTimeColumn('insert_timestamp'); // Reset time column when opening new item
-      
+      setTimeColumn("insert_timestamp"); // Reset time column when opening new item
+
       // Only fetch SQL data if get data nodes confirmed there is a table at this location
       const itemData = getItemData(item);
       const hasTableMeta = itemData && itemData.dbms && itemData.table;
-      const tableCacheKey = hasTableMeta ? `${itemData.dbms}:${itemData.table}` : null;
-      const hasDataAtLocation = tableCacheKey ? (itemsWithData.get(tableCacheKey) === true) : false;
+      const tableCacheKey = hasTableMeta
+        ? `${itemData.dbms}:${itemData.table}`
+        : null;
+      const hasDataAtLocation = tableCacheKey
+        ? itemsWithData.get(tableCacheKey) === true
+        : false;
       if (hasDataAtLocation) {
-        fetchSqlData(itemData.dbms, itemData.table, itemData.where, itemData.column);
+        fetchSqlData(
+          itemData.dbms,
+          itemData.table,
+          itemData.where,
+          itemData.column,
+        );
       }
     }
   };
@@ -746,7 +840,7 @@ const UNSPage = ({ node }) => {
     const expandedKey = `${layerIndex}-${itemId}`;
     const itemKey = `${layerIndex}-${itemId}`;
     const isExpanded = expandedItems.has(expandedKey);
-    
+
     // Check if this item has children
     // If we've already checked and it has no children, it's a leaf
     const hasNoChildren = itemsWithoutChildren.has(itemKey);
@@ -754,32 +848,41 @@ const UNSPage = ({ node }) => {
     const hasChildren = itemsWithChildren.has(itemKey) || isExpanded;
     // Check if currently checking for children
     const isCheckingChildren = checkingChildren.has(itemId);
-    
+
     // Check if item has table data (for visual indicator)
     const hasTable = itemData && itemData.dbms && itemData.table;
-    const tableCacheKey = hasTable ? `${itemData.dbms}:${itemData.table}` : null;
-    const hasData = tableCacheKey ? (itemsWithData.get(tableCacheKey) ?? null) : null;
-    const isCheckingData = tableCacheKey ? checkingData.has(tableCacheKey) : false;
-    
+    const tableCacheKey = hasTable
+      ? `${itemData.dbms}:${itemData.table}`
+      : null;
+    const hasData = tableCacheKey
+      ? (itemsWithData.get(tableCacheKey) ?? null)
+      : null;
+    const isCheckingData = tableCacheKey
+      ? checkingData.has(tableCacheKey)
+      : false;
+
     // Determine icon based on whether item has children
-    let icon = '📄'; // Default file icon
+    let icon = "📄"; // Default file icon
     if (hasChildren) {
-      icon = isExpanded ? '📂' : '📁'; // Folder icons (open/closed)
+      icon = isExpanded ? "📂" : "📁"; // Folder icons (open/closed)
     } else if (hasNoChildren) {
       // Item confirmed to have no children - use file icon
-      icon = '📄';
+      icon = "📄";
     } else if (isCheckingChildren) {
       // Still checking - show folder icon as placeholder (will update when check completes)
-      icon = '📁';
+      icon = "📁";
     } else {
       // Not checked yet - show folder icon as default (will be updated when background check completes)
-      icon = '📁';
+      icon = "📁";
     }
 
     const handleItemClick = (e) => {
       // Left click: only expand/collapse if item has children or might have children
       // Don't expand if clicking on the info button
-      if ((hasChildren || !hasNoChildren) && !e.target.closest('.uns-item-info-btn')) {
+      if (
+        (hasChildren || !hasNoChildren) &&
+        !e.target.closest(".uns-item-info-btn")
+      ) {
         expandItem(item, layerIndex);
       }
     };
@@ -797,34 +900,43 @@ const UNSPage = ({ node }) => {
     };
 
     const isSelected = selectedItem && getItemId(selectedItem) === itemId;
-    
+
     // Add data indicator class ONLY if item definitively has data (true)
     // Don't add any class if hasData is false or null (no data or not checked)
-    const dataIndicatorClass = hasData === true ? 'has-data' : '';
-    const checkingClass = isCheckingData ? 'checking-data' : '';
+    const dataIndicatorClass = hasData === true ? "has-data" : "";
+    const checkingClass = isCheckingData ? "checking-data" : "";
 
     return (
       <div
         key={`${layerIndex}-${itemIndex}-${itemId}`}
-        className={`uns-item ${isExpanded ? 'expanded' : ''} ${isSelected ? 'selected' : ''} ${dataIndicatorClass} ${checkingClass}`}
+        className={`uns-item ${isExpanded ? "expanded" : ""} ${isSelected ? "selected" : ""} ${dataIndicatorClass} ${checkingClass}`}
         onMouseEnter={(e) => handleItemHover(e, item)}
         onMouseLeave={handleItemLeave}
         onClick={handleItemClick}
         onContextMenu={handleItemRightClick}
-        style={{ cursor: (hasChildren || !hasNoChildren) ? 'pointer' : 'default' }}
+        style={{
+          cursor: hasChildren || !hasNoChildren ? "pointer" : "default",
+        }}
       >
-        <div className="uns-item-icon">
-          {icon}
-        </div>
+        <div className="uns-item-icon">{icon}</div>
         <div className="uns-item-name">
           {itemName}
           {/* Only show data indicator if we have a definitive result (true = has data) */}
           {/* Don't show anything if hasData is false or null (no data or not checked yet) */}
           {hasTable && hasData === true && (
-            <span className="uns-item-data-indicator" title="Table has data"> 💾</span>
+            <span className="uns-item-data-indicator" title="Table has data">
+              {" "}
+              💾
+            </span>
           )}
           {hasTable && isCheckingData && (
-            <span className="uns-item-data-indicator checking" title="Checking for data..."> ⏳</span>
+            <span
+              className="uns-item-data-indicator checking"
+              title="Checking for data..."
+            >
+              {" "}
+              ⏳
+            </span>
           )}
         </div>
         <div className="uns-item-actions">
@@ -837,9 +949,7 @@ const UNSPage = ({ node }) => {
             ℹ️
           </button>
           {(hasChildren || !hasNoChildren) && (
-            <div className="uns-item-expand">
-              {isExpanded ? '▼' : '▶'}
-            </div>
+            <div className="uns-item-expand">{isExpanded ? "▼" : "▶"}</div>
           )}
         </div>
       </div>
@@ -857,7 +967,7 @@ const UNSPage = ({ node }) => {
       // setItemsWithoutChildren(new Set());
     }
     // Scroll to top when going to root
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const renderBreadcrumb = () => {
@@ -865,10 +975,7 @@ const UNSPage = ({ node }) => {
 
     return (
       <div className="uns-breadcrumb">
-        <button 
-          className="uns-breadcrumb-item" 
-          onClick={navigateToRoot}
-        >
+        <button className="uns-breadcrumb-item" onClick={navigateToRoot}>
           🏠 Root
         </button>
         {currentPath.map((pathItem, index) => {
@@ -876,24 +983,24 @@ const UNSPage = ({ node }) => {
           // path[0] shows layer 1, path[1] shows layer 2, etc.
           const targetLayerIndex = index + 1;
           const isCurrentLayer = targetLayerIndex === layers.length - 1;
-          
+
           return (
             <React.Fragment key={index}>
               <span className="uns-breadcrumb-separator">/</span>
               <button
-                className={`uns-breadcrumb-item ${isCurrentLayer ? 'uns-breadcrumb-current' : ''}`}
+                className={`uns-breadcrumb-item ${isCurrentLayer ? "uns-breadcrumb-current" : ""}`}
                 onClick={() => {
                   // If clicking on the current layer, do nothing (or could scroll to top)
                   if (!isCurrentLayer) {
                     navigateToLayer(targetLayerIndex);
                   } else {
                     // Already on this layer, just scroll to top
-                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                    window.scrollTo({ top: 0, behavior: "smooth" });
                   }
                 }}
-                style={{ 
-                  cursor: isCurrentLayer ? 'default' : 'pointer',
-                  fontWeight: isCurrentLayer ? 'bold' : 'normal'
+                style={{
+                  cursor: isCurrentLayer ? "default" : "pointer",
+                  fontWeight: isCurrentLayer ? "bold" : "normal",
                 }}
               >
                 {pathItem.name}
@@ -905,21 +1012,22 @@ const UNSPage = ({ node }) => {
     );
   };
 
-
   return (
     <div className="uns-container">
       <div className="uns-header">
         <h1>Unified Namespace (UNS)</h1>
         <div className="uns-header-controls">
           <div className="uns-query-input-group">
-            <label htmlFor="root-query" className="uns-query-label">Root Query:</label>
+            <label htmlFor="root-query" className="uns-query-label">
+              Root Query:
+            </label>
             <input
               id="root-query"
               type="text"
               value={rootQuery}
               onChange={(e) => setRootQuery(e.target.value)}
               onKeyPress={(e) => {
-                if (e.key === 'Enter' && !loading && node) {
+                if (e.key === "Enter" && !loading && node) {
                   loadRootItems();
                 }
               }}
@@ -928,8 +1036,8 @@ const UNSPage = ({ node }) => {
               disabled={loading}
             />
           </div>
-          <button 
-            onClick={loadRootItems} 
+          <button
+            onClick={loadRootItems}
             disabled={loading || !node || !rootQuery.trim()}
             className="uns-refresh-btn"
           >
@@ -944,43 +1052,43 @@ const UNSPage = ({ node }) => {
         </div>
       )}
 
-      {error && (
-        <div className="uns-error">
-          <span className="error-dismiss" onClick={() => setError(null)}>×</span>
-          ❌ Error: {error}
-        </div>
-      )}
+      {error && <div className="uns-error">❌ Error: {error}</div>}
 
-      <div className={`uns-main-content ${isSidePanelOpen ? 'uns-panel-open' : ''}`}>
+      <div
+        className={`uns-main-content ${isSidePanelOpen ? "uns-panel-open" : ""}`}
+      >
         <div className="uns-main-content-wrapper">
           {renderBreadcrumb()}
 
           <div className="uns-layers">
-        {layers.length > 0 && (() => {
-          // Only show the current layer (the last one)
-          const currentLayerIndex = layers.length - 1;
-          const currentLayer = layers[currentLayerIndex];
-          const layerName = currentLayerIndex === 0 
-            ? 'Root' 
-            : (currentPath[currentLayerIndex - 1]?.name || `Layer ${currentLayerIndex}`);
-          
-          return (
-            <div key={currentLayerIndex} className="uns-layer">
-              <div className="uns-layer-header">
-                {layerName}
-              </div>
-              <div className="uns-layer-content">
-                {loading ? (
-                  <div className="uns-loading">Loading...</div>
-                ) : currentLayer.length === 0 ? (
-                  <div className="uns-empty">No items found</div>
-                ) : (
-                  currentLayer.map((item, itemIndex) => renderItem(item, currentLayerIndex, itemIndex))
-                )}
-              </div>
-            </div>
-          );
-        })()}
+            {layers.length > 0 &&
+              (() => {
+                // Only show the current layer (the last one)
+                const currentLayerIndex = layers.length - 1;
+                const currentLayer = layers[currentLayerIndex];
+                const layerName =
+                  currentLayerIndex === 0
+                    ? "Root"
+                    : currentPath[currentLayerIndex - 1]?.name ||
+                      `Layer ${currentLayerIndex}`;
+
+                return (
+                  <div key={currentLayerIndex} className="uns-layer">
+                    <div className="uns-layer-header">{layerName}</div>
+                    <div className="uns-layer-content">
+                      {loading ? (
+                        <div className="uns-loading">Loading...</div>
+                      ) : currentLayer.length === 0 ? (
+                        <div className="uns-empty">No items found</div>
+                      ) : (
+                        currentLayer.map((item, itemIndex) =>
+                          renderItem(item, currentLayerIndex, itemIndex),
+                        )
+                      )}
+                    </div>
+                  </div>
+                );
+              })()}
           </div>
         </div>
 
@@ -1005,6 +1113,7 @@ const UNSPage = ({ node }) => {
           }}
           onTimeRangeValueChange={setTimeRangeValue}
           onTimeRangeUnitChange={setTimeRangeUnit}
+          onFetchTimeRange={fetchMetadata}
           onFetchTimeRange={fetchSqlData}
           getItemName={getItemName}
           getItemType={getItemType}
@@ -1020,12 +1129,14 @@ const UNSPage = ({ node }) => {
           className="uns-tooltip"
           style={{
             left: `${hoverPosition.x + 10}px`,
-            top: `${hoverPosition.y + 10}px`
+            top: `${hoverPosition.y + 10}px`,
           }}
         >
           <div className="uns-tooltip-header">
             <strong>{getItemName(hoveredItem)}</strong>
-            <span className="uns-tooltip-type">({getItemType(hoveredItem)})</span>
+            <span className="uns-tooltip-type">
+              ({getItemType(hoveredItem)})
+            </span>
           </div>
           <div className="uns-tooltip-content">
             <pre>{JSON.stringify(getItemData(hoveredItem), null, 2)}</pre>
@@ -1038,9 +1149,8 @@ const UNSPage = ({ node }) => {
 
 // Plugin metadata
 export const pluginMetadata = {
-  name: 'Unified Namespace',
-  icon: null
+  name: "Unified Namespace",
+  icon: null,
 };
 
 export default UNSPage;
-

--- a/CLI/local-cli-fe-full/src/plugins/uns/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/uns/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/plugins/videostreamviewer/devContext.js
+++ b/CLI/local-cli-fe-full/src/plugins/videostreamviewer/devContext.js
@@ -1,0 +1,1 @@
+export * from "../devContext";

--- a/CLI/local-cli-fe-full/src/services/featureConfig.js
+++ b/CLI/local-cli-fe-full/src/services/featureConfig.js
@@ -26,22 +26,22 @@ export const fetchFeatureConfig = async () => {
         cachedFeatureConfig = data;
         return cachedFeatureConfig;
       } else {
-        console.warn('Failed to fetch feature config:', response.status);
+        console.warn("Failed to fetch feature config:", response.status);
         // Return default: all features enabled
         cachedFeatureConfig = {
           features: {},
           plugins: {},
-          version: "1.0.0"
+          version: "1.0.0",
         };
         return cachedFeatureConfig;
       }
     } catch (error) {
-      console.warn('Failed to fetch feature config:', error);
+      console.warn("Failed to fetch feature config:", error);
       // Return default: all features enabled
       cachedFeatureConfig = {
         features: {},
         plugins: {},
-        version: "1.0.0"
+        version: "1.0.0",
       };
       return cachedFeatureConfig;
     }
@@ -59,11 +59,11 @@ export const fetchFeatureConfig = async () => {
 export const isFeatureEnabled = async (featureName) => {
   const config = await fetchFeatureConfig();
   const features = config.features || {};
-  
+
   if (!(featureName in features)) {
     return false;
   }
-  
+
   return features[featureName].enabled !== false;
 };
 
@@ -76,11 +76,11 @@ export const isFeatureEnabled = async (featureName) => {
 export const isPluginEnabled = async (pluginName) => {
   const config = await fetchFeatureConfig();
   const plugins = config.plugins || {};
-  
+
   if (!(pluginName in plugins)) {
     return false;
   }
-  
+
   return plugins[pluginName].enabled !== false;
 };
 
@@ -92,13 +92,13 @@ export const getEnabledFeatures = async () => {
   const config = await fetchFeatureConfig();
   const features = config.features || {};
   const enabled = new Set();
-  
+
   for (const [name, data] of Object.entries(features)) {
     if (data.enabled !== false) {
       enabled.add(name);
     }
   }
-  
+
   return enabled;
 };
 
@@ -110,13 +110,13 @@ export const getEnabledPlugins = async () => {
   const config = await fetchFeatureConfig();
   const plugins = config.plugins || {};
   const enabled = new Set();
-  
+
   for (const [name, data] of Object.entries(plugins)) {
     if (data.enabled !== false) {
       enabled.add(name);
     }
   }
-  
+
   return enabled;
 };
 
@@ -126,4 +126,29 @@ export const getEnabledPlugins = async () => {
  */
 export const initializeFeatureConfig = () => {
   return fetchFeatureConfig();
+};
+
+export const invalidateFeatureConfig = () => {
+  cachedFeatureConfig = null;
+  configFetchPromise = null;
+};
+
+export const setPluginEnabled = async (pluginName, enabled) => {
+  const API_URL = window._env_?.REACT_APP_API_URL || "http://localhost:8000";
+  const response = await fetch(
+    `${API_URL}/feature-config/plugins/${pluginName}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => response.statusText);
+    throw new Error(`Failed to update plugin "${pluginName}": ${detail}`);
+  }
+
+  invalidateFeatureConfig();
+  await fetchFeatureConfig();
 };

--- a/CLI/local-cli-fe-full/src/styles/Dashboard.css
+++ b/CLI/local-cli-fe-full/src/styles/Dashboard.css
@@ -1,18 +1,26 @@
 /* src/styles/Dashboard.css */
 .dashboard-container {
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-  }
-  
-  .dashboard-content {
-    display: flex;
-    flex: 1;
-  }
-  
-  .dashboard-main {
-    flex: 1;
-    padding: 20px;
-    overflow-y: auto;
-  }
-  
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.dashboard-content {
+  display: flex;
+  flex: 1;
+}
+
+.dashboard-main {
+  flex: 1;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.dashboard-plugin-frame {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  width: 100%;
+  align-self: stretch;
+}

--- a/CLI/local-cli-fe-full/src/styles/Sidebar.css
+++ b/CLI/local-cli-fe-full/src/styles/Sidebar.css
@@ -15,7 +15,9 @@
   font-size: 16px;
   padding: 8px 12px;
   border-radius: 8px;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
   display: block;
 }
 
@@ -69,4 +71,14 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.installed-plugin-section {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid #4e4e6a;
+}
+
+.installed-plugin-section a {
+  margin-bottom: 12px;
 }

--- a/CLI/local-cli-fe-full/vite.config.js
+++ b/CLI/local-cli-fe-full/vite.config.js
@@ -1,32 +1,66 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { federation } from "@module-federation/vite";
+import { generateExposes } from "./scripts/generateFederationExposes.js";
+
+const exposes = generateExposes();
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    federation({
+      name: "host",
+      filename: "remoteEntry.js",
+      dts: false,
+      remotes: {},
+      exposes,
+      shared: {
+        react: { singleton: true, requiredVersion: "^19.0.0", eager: true },
+        "react-dom": {
+          singleton: true,
+          requiredVersion: "^19.0.0",
+          eager: true,
+        },
+        "react/jsx-runtime": {
+          singleton: true,
+          requiredVersion: "^19.0.0",
+          eager: true,
+        },
+        tslib: { singleton: true, requiredVersion: false },
+      },
+    }),
+  ],
   build: {
-    outDir: 'build',
-    commonjsOptions: {
-      transformMixedEsModules: true
-    }
+    target: "esnext",
+    outDir: "build",
+    rollupOptions: {
+      output: { format: "esm" },
+    },
+  },
+  preview: {
+    port: 3000,
+    strictPort: true,
+    cors: true,
+    headers: { "Access-Control-Allow-Origin": "*" },
   },
   esbuild: {
-    loader: 'jsx',
+    loader: "jsx",
     include: /src\/.*\.js$/,
-    exclude: []
+    exclude: [],
   },
   optimizeDeps: {
     include: [
-      'tslib',
-      'dexie-encrypted',
-      'jspdf',
-      'jspdf-autotable',
-      'xterm',
-      'xterm-addon-fit'
+      "tslib",
+      "dexie-encrypted",
+      "jspdf",
+      "jspdf-autotable",
+      "xterm",
+      "xterm-addon-fit",
     ],
     esbuildOptions: {
       loader: {
-        '.js': 'jsx'
-      }
-    }
-  }
-})
+        ".js": "jsx",
+      },
+    },
+  },
+});


### PR DESCRIPTION
Adds an end-to-end plugin marketplace to the Remote GUI: browse plugin registries, download and install plugin packages (frontend + backend), enable/disable them at a runtime-level, and load installed plugin UIs into the main app via Vite's Module Federation while routing each plugin’s API through the host backend. These additions introduces downloadable, versioned, separately deployed plugins without rebuilding the host. 

Demo is available here: https://drive.google.com/file/d/1FsKRw56Hvpuuw5zZOhiZPvVM4eJlrVhn/view?usp=sharing
