### PR TITLE
fixing uns crash when there's no data in the table

### DIFF
--- a/CLI/local-cli-backend/plugins/uns/uns_router.py
+++ b/CLI/local-cli-backend/plugins/uns/uns_router.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from typing import Optional
 from plugins.utils import make_request
 from parsers import parse_response
-from plugins.utils import get_data_nodes_for_table
+from plugins.utils import get_columns, get_data_nodes_for_table
 
 # Create the API router
 api_router = APIRouter(prefix="/uns", tags=["UNS"])
@@ -187,6 +187,20 @@ def _extract_sql_error_message(response) -> str:
     return str(response)[:300]
 
 
+def _get_visible_columns(conn: str, dbms: str, table: str) -> list:
+    """Return displayable column names for a table."""
+    columns = get_columns(conn, dbms, table)
+    names = []
+    for column in columns:
+        if isinstance(column, dict):
+            name = column.get("column_name") or column.get("name")
+        else:
+            name = str(column)
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
 @api_router.post("/query-table")
 async def query_table(request: QueryTableRequest):
     """Query table data for the last N hours"""
@@ -230,6 +244,8 @@ async def query_table(request: QueryTableRequest):
         print(f"UNS: Connection: {request.conn}")
         print(f"UNS: DBMS: {request.dbms}, Table: {request.table}, Time: {time_value} {time_unit}")
 
+        columns = _get_visible_columns(request.conn, request.dbms, request.table)
+
         # Execute query - catch connection/SQL errors
         try:
             response = make_request(request.conn, "GET", command)
@@ -237,7 +253,7 @@ async def query_table(request: QueryTableRequest):
             err_msg = str(req_err)
             print(f"UNS: make_request failed: {err_msg}")
             friendly = _extract_sql_error_message(err_msg)
-            return {"success": False, "error": friendly if len(friendly) > 10 else err_msg, "data": None}
+            return {"success": False, "error": friendly if len(friendly) > 10 else err_msg, "data": [], "columns": columns}
 
         # Check for error response before parsing (e.g. err_code, type=error)
         if isinstance(response, dict) and (
@@ -245,7 +261,7 @@ async def query_table(request: QueryTableRequest):
         ):
             err_msg = _extract_sql_error_message(response)
             print(f"UNS: SQL/connection error in response: {err_msg}")
-            return {"success": False, "error": err_msg, "data": None}
+            return {"success": False, "error": err_msg, "data": [], "columns": columns}
 
         # Parse response - catch parse errors
         try:
@@ -253,7 +269,7 @@ async def query_table(request: QueryTableRequest):
         except Exception as parse_err:
             err_msg = str(parse_err)
             print(f"UNS: parse_response failed: {err_msg}")
-            return {"success": False, "error": _extract_sql_error_message(response) or f"Failed to parse response: {err_msg}", "data": None}
+            return {"success": False, "error": _extract_sql_error_message(response) or f"Failed to parse response: {err_msg}", "data": [], "columns": columns}
 
         # Extract data from response
         if isinstance(parsed, dict) and "data" in parsed:
@@ -268,7 +284,8 @@ async def query_table(request: QueryTableRequest):
                 return {
                     "success": False,
                     "error": parsed.get("data", "Unknown error occurred"),
-                    "data": None
+                    "data": [],
+                    "columns": columns
                 }
             data = parsed.get("data", parsed)
             # print(f"UNS: Extracted from parsed dict, type: {type(data)}, length: {len(data) if isinstance(data, list) else 'N/A'}")
@@ -282,7 +299,10 @@ async def query_table(request: QueryTableRequest):
                 import json
                 data = json.loads(data)
             except (json.JSONDecodeError, ValueError):
-                pass
+                if data.startswith("Error parsing response:") and columns:
+                    data = []
+                else:
+                    return {"success": False, "error": data, "data": [], "columns": columns}
         
         # Ensure data is a list
         if not isinstance(data, list):
@@ -316,6 +336,7 @@ async def query_table(request: QueryTableRequest):
         return {
             "success": True,
             "data": filtered_data,
+            "columns": columns,
             "error": None
         }
     except Exception as e:
@@ -324,7 +345,8 @@ async def query_table(request: QueryTableRequest):
         return {
             "success": False,
             "error": error_msg,
-            "data": None
+            "data": [],
+            "columns": []
         }
 
 @api_router.post("/query-custom")
@@ -485,22 +507,22 @@ async def column_details(request: ColumnDetailsRequest):
 
 @api_router.post("/check-table")
 async def check_table(request: CheckTableRequest):
-    """Check if a table exists at the location using get data nodes (returns empty list if no table)."""
+    """Check if a table exists at the location using table columns."""
     try:
         if not request.dbms or not request.table:
             raise HTTPException(status_code=400, detail="dbms and table are required")
         
-        # Use get data nodes: returns empty list if no table at this location (no error)
-        nodes = get_data_nodes_for_table(request.conn, request.dbms, request.table)
-        has_data = len(nodes) > 0
+        columns = _get_visible_columns(request.conn, request.dbms, request.table)
+        has_data = len(columns) > 0
         
         if not has_data:
-            print(f"UNS: No data nodes for {request.dbms}.{request.table} - treating as no table")
+            print(f"UNS: No columns for {request.dbms}.{request.table} - treating as no table")
         
         return {
             "success": True,
             "has_data": has_data,
-            "column_count": len(nodes),  # number of nodes matching dbms/table
+            "columns": columns,
+            "column_count": len(columns),
             "error": None
         }
     except Exception as e:
@@ -509,6 +531,7 @@ async def check_table(request: CheckTableRequest):
         return {
             "success": False,
             "has_data": False,
+            "columns": [],
             "column_count": 0,
             "error": error_msg
         }
@@ -613,4 +636,3 @@ async def check_children(request: CheckChildrenRequest):
             "child_count": 0,
             "error": error_msg
         }
-

--- a/CLI/local-cli-fe-full/src/plugins/uns/UNSColumnDetails.js
+++ b/CLI/local-cli-fe-full/src/plugins/uns/UNSColumnDetails.js
@@ -11,7 +11,7 @@ function isColumnNumerical(sqlData, columnName) {
   let checked = 0;
   for (let i = 0; i < Math.min(sqlData.length, 20); i++) {
     const row = sqlData[i];
-    if (row && columnName in row) {
+    if (row && typeof row === 'object' && !Array.isArray(row) && columnName in row) {
       const v = row[columnName];
       if (v != null && v !== '') {
         checked++;

--- a/CLI/local-cli-fe-full/src/plugins/uns/UNSLineChart.js
+++ b/CLI/local-cli-fe-full/src/plugins/uns/UNSLineChart.js
@@ -135,11 +135,15 @@ const UNSLineChart = forwardRef(({ sqlData, chartYKey, onChartYKeyChange, prefer
   }
 
   const firstRow = sqlData[0];
+  if (!firstRow || typeof firstRow !== 'object' || Array.isArray(firstRow)) {
+    return null;
+  }
+
   const desiredTimeKey = timeColumnKey || 'insert_timestamp';
-  const timeKey = firstRow && (desiredTimeKey in firstRow)
+  const timeKey = desiredTimeKey in firstRow
     ? desiredTimeKey
-    : firstRow && Object.keys(firstRow).find((k) => k.toLowerCase() === (desiredTimeKey || '').toLowerCase());
-  if (!firstRow || !timeKey) {
+    : Object.keys(firstRow).find((k) => k.toLowerCase() === (desiredTimeKey || '').toLowerCase());
+  if (!timeKey) {
     return null;
   }
 

--- a/CLI/local-cli-fe-full/src/plugins/uns/UNSPage.js
+++ b/CLI/local-cli-fe-full/src/plugins/uns/UNSPage.js
@@ -21,6 +21,7 @@ const UNSPage = ({ node }) => {
   const [timeRangeUnit, setTimeRangeUnit] = useState('minute'); // Time range unit (default: minute)
   const [timeColumn, setTimeColumn] = useState('insert_timestamp'); // Time column: insert_timestamp or timestamp
   const [sqlData, setSqlData] = useState(null); // SQL query results
+  const [sqlColumns, setSqlColumns] = useState([]); // SQL table columns
   const [sqlLoading, setSqlLoading] = useState(false); // SQL query loading state
   const [sqlError, setSqlError] = useState(null); // SQL query error
   const [chartYKey, setChartYKey] = useState(null); // Selected value column for line chart
@@ -682,9 +683,12 @@ const UNSPage = ({ node }) => {
         console.log(
           `UNS: Setting ${result.data ? result.data.length : 0} rows in state`,
         );
-        setSqlData(result.data);
+        setSqlData(Array.isArray(result.data) ? result.data : []);
+        setSqlColumns(Array.isArray(result.columns) ? result.columns : []);
         if (silent) setSqlError(null);
       } else {
+        setSqlData(Array.isArray(result.data) ? result.data : []);
+        setSqlColumns(Array.isArray(result.columns) ? result.columns : []);
         setSqlError(result.error || 'Failed to fetch table data');
       }
     } catch (err) {
@@ -767,26 +771,21 @@ const UNSPage = ({ node }) => {
       setIsSidePanelOpen(false);
       setSelectedItem(null);
       setSqlData(null);
+      setSqlColumns([]);
       setSqlError(null);
     } else {
       // Otherwise, open/update the side panel with this item
       setSelectedItem(item);
       setIsSidePanelOpen(true);
       setSqlData(null);
+      setSqlColumns([]);
       setSqlError(null);
       setChartYKey(null); // Reset so chart defaults to policy column for new item
       setTimeColumn('insert_timestamp'); // Reset time column when opening new item
 
-      // Only fetch SQL data if get data nodes confirmed there is a table at this location
       const itemData = getItemData(item);
       const hasTableMeta = itemData && itemData.dbms && itemData.table;
-      const tableCacheKey = hasTableMeta
-        ? `${itemData.dbms}:${itemData.table}`
-        : null;
-      const hasDataAtLocation = tableCacheKey
-        ? itemsWithData.get(tableCacheKey) === true
-        : false;
-      if (hasDataAtLocation) {
+      if (hasTableMeta) {
         fetchSqlData(
           itemData.dbms,
           itemData.table,
@@ -866,8 +865,8 @@ const UNSPage = ({ node }) => {
 
     const isSelected = selectedItem && getItemId(selectedItem) === itemId;
 
-    // Add data indicator class ONLY if item definitively has data (true)
-    // Don't add any class if hasData is false or null (no data or not checked)
+    // Add table indicator class only if the table schema is available.
+    // Don't add any class if hasData is false or null (no table or not checked)
     const dataIndicatorClass = hasData === true ? 'has-data' : '';
     const checkingClass = isCheckingData ? 'checking-data' : '';
 
@@ -886,10 +885,10 @@ const UNSPage = ({ node }) => {
         <div className="uns-item-icon">{icon}</div>
         <div className="uns-item-name">
           {itemName}
-          {/* Only show data indicator if we have a definitive result (true = has data) */}
-          {/* Don't show anything if hasData is false or null (no data or not checked yet) */}
+          {/* Only show table indicator if we have a definitive result (true = table available) */}
+          {/* Don't show anything if hasData is false or null (no table or not checked yet) */}
           {hasTable && hasData === true && (
-            <span className="uns-item-data-indicator" title="Table has data">
+            <span className="uns-item-data-indicator" title="Table available">
               {' '}
               💾
             </span>
@@ -897,7 +896,7 @@ const UNSPage = ({ node }) => {
           {hasTable && isCheckingData && (
             <span
               className="uns-item-data-indicator checking"
-              title="Checking for data..."
+              title="Checking table..."
             >
               {' '}
               ⏳
@@ -1068,9 +1067,9 @@ const UNSPage = ({ node }) => {
         <UNSSidePanel
           isOpen={isSidePanelOpen}
           selectedItem={selectedItem}
-          itemsWithData={itemsWithData}
           conn={node}
           sqlData={sqlData}
+          sqlColumns={sqlColumns}
           sqlLoading={sqlLoading}
           sqlError={sqlError}
           timeRangeValue={timeRangeValue}
@@ -1081,6 +1080,7 @@ const UNSPage = ({ node }) => {
             setIsSidePanelOpen(false);
             setSelectedItem(null);
             setSqlData(null);
+            setSqlColumns([]);
             setSqlError(null);
           }}
           onTimeRangeValueChange={setTimeRangeValue}

--- a/CLI/local-cli-fe-full/src/plugins/uns/UNSSidePanel.js
+++ b/CLI/local-cli-fe-full/src/plugins/uns/UNSSidePanel.js
@@ -8,9 +8,9 @@ import { getDataNodes } from './uns_api';
 const UNSSidePanel = ({
   isOpen,
   selectedItem,
-  itemsWithData,
   conn,
   sqlData,
+  sqlColumns,
   sqlLoading,
   sqlError,
   timeRangeValue,
@@ -30,9 +30,7 @@ const UNSSidePanel = ({
 }) => {
   const itemData = selectedItem ? getItemData(selectedItem) : null;
   const hasTableMeta = itemData && itemData.dbms && itemData.table;
-  const tableCacheKey = hasTableMeta ? `${itemData.dbms}:${itemData.table}` : null;
-  const hasDataAtLocation = tableCacheKey ? (itemsWithData.get(tableCacheKey) === true) : false;
-  const showTableSection = hasTableMeta && hasDataAtLocation;
+  const showTableSection = hasTableMeta;
   const chartRef = useRef(null);
 
   const [dataNodes, setDataNodes] = useState(null);
@@ -106,9 +104,11 @@ const UNSSidePanel = ({
   const sanitizeForFilename = (s) => (s != null ? String(s).replace(/[/\\:*?"<>|]/g, '-').trim() : '');
 
   /** Get table columns in order: selected time column first (if present), then others. Only show one time column. */
-  const getOrderedTableColumns = (firstRow) => {
-    if (!firstRow || typeof firstRow !== 'object') return [];
-    const keys = Object.keys(firstRow);
+  const getOrderedTableColumns = (source) => {
+    const keys = Array.isArray(source)
+      ? source
+      : (source && typeof source === 'object' ? Object.keys(source) : []);
+    if (keys.length === 0) return [];
     const keyMatches = (k, target) => k === target || (k && target && String(k).toLowerCase() === String(target).toLowerCase());
     const timeCols = ['insert_timestamp', 'timestamp'];
     const selectedTimeKey = keys.find((k) => keyMatches(k, timeColumn));
@@ -121,6 +121,12 @@ const UNSSidePanel = ({
     }
     return keys;
   };
+
+  const tableColumns = Array.isArray(sqlData) && sqlData[0] && typeof sqlData[0] === 'object'
+    ? getOrderedTableColumns(sqlData[0])
+    : (Array.isArray(sqlColumns) && sqlColumns.length > 0
+      ? getOrderedTableColumns(sqlColumns)
+      : []);
 
   const getExportFilename = () => {
     const parts = [
@@ -291,19 +297,21 @@ const UNSSidePanel = ({
                           <span className="uns-live-dot" /> LIVE — {refreshRate}s
                         </span>
                       )}
-                      {sqlData && sqlData.length > 0 && (
+                      {Array.isArray(sqlData) && (
                         <>
                           <span className="uns-sql-row-count">
                             ({sqlData.length} row{sqlData.length !== 1 ? 's' : ''})
                           </span>
-                          <div className="uns-sql-export-btns">
-                            <button type="button" onClick={handleExportCSV} className="uns-export-btn" title="Export table to CSV">
-                              Export CSV
-                            </button>
-                            <button type="button" onClick={handleExportPDF} className="uns-export-btn" title="Export table and chart to PDF">
-                              Export PDF
-                            </button>
-                          </div>
+                          {sqlData.length > 0 && (
+                            <div className="uns-sql-export-btns">
+                              <button type="button" onClick={handleExportCSV} className="uns-export-btn" title="Export table to CSV">
+                                Export CSV
+                              </button>
+                              <button type="button" onClick={handleExportPDF} className="uns-export-btn" title="Export table and chart to PDF">
+                                Export PDF
+                              </button>
+                            </div>
+                          )}
                         </>
                       )}
                     </div>
@@ -325,28 +333,25 @@ const UNSSidePanel = ({
                     {!sqlLoading && !sqlError && Array.isArray(sqlData) && (
                       <>
                         <div className="uns-sql-table-container">
-                          {sqlData.length === 0 ? (
+                          {tableColumns.length === 0 && sqlData.length === 0 ? (
                             <div className="uns-sql-empty">
-                              No data found for the specified time range.
+                              No columns found for this table.
                             </div>
                           ) : (
                             <table className="uns-sql-table">
                               <thead>
                                 <tr>
-                                  {sqlData[0] && getOrderedTableColumns(sqlData[0]).map((key) => (
+                                  {tableColumns.map((key) => (
                                     <th key={key}>{key}</th>
                                   ))}
                                 </tr>
                               </thead>
                               <tbody>
                                 {sqlData.map((row, index) => {
-                                  const orderedKeys = sqlData[0] && typeof sqlData[0] === 'object'
-                                    ? getOrderedTableColumns(sqlData[0])
-                                    : (row && typeof row === 'object' ? Object.keys(row) : []);
                                   return (
                                     <tr key={index}>
                                       {row && typeof row === 'object'
-                                        ? orderedKeys.map((key) => (
+                                        ? tableColumns.map((key) => (
                                             <td key={key}>
                                               {key in row
                                                 ? (typeof row[key] === 'object' && row[key] !== null
@@ -355,7 +360,7 @@ const UNSSidePanel = ({
                                                 : ''}
                                             </td>
                                           ))
-                                        : <td>{String(row ?? '')}</td>}
+                                        : <td colSpan={Math.max(tableColumns.length, 1)}>{String(row ?? '')}</td>}
                                     </tr>
                                   );
                                 })}
@@ -446,4 +451,3 @@ const UNSSidePanel = ({
 };
 
 export default UNSSidePanel;
-


### PR DESCRIPTION
When there was no rows populated in the table, the UNS line chart display graph and table would crash. This fixes it. When there are no rows, the table is displayed with just the headers.